### PR TITLE
WIP Arm Forge initial easyconfig

### DIFF
--- a/easybuild/easyconfigs/a/Arm-Forge/Arm-Forge-22.0.eb
+++ b/easybuild/easyconfigs/a/Arm-Forge/Arm-Forge-22.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'EB_Allinea'
+
+name = 'Arm-Forge'
+version = '22.0'
+
+homepage = 'https://developer.arm.com/'
+
+whatis = ['Arm Forge']
+
+description = """Arm Forge is the leading server and HPC development tool suite in research, industry, and academia for C, C++, Fortran, and Python high performance code on Linux."""
+
+usage = """To run Arm Forge from command line use `--offline` option.
+
+To run with graphical user interface use VNC container with the following additional modules: `X11` `lumi-vnc`
+"""  
+
+toolchain = SYSTEM
+
+sources = ['%(namelower)s-%(version)s-linux-x86_64.tar']
+extract_sources = 'True'
+
+license_file = '/projappl/project_462000002/FORGE/Licence'
+
+builddependencies = []
+
+#install_cmd = 'bash %(installdir)s/%(namelower)s-%(version)s-linux-x86_64/textinstall.sh --accept-license %(installdir)s'
+
+prepend_to_path = ['bin']
+
+modextravars = {'SINGULARITY_BINDPATH':'/appl:/appl,/opt/cray:/opt/cray,/usr/share/fonts:/usr/share/fonts', 'SINGULARITYENV_LD_LIBRARY_PATH':'/opt/cray/xpmem/2.2.40-2.1_3.9__g3cf3325.shasta/lib64:$EBROOTX11/lib', 'SINGULARITYENV_PREPEND_PATH': '%(installdir)s/bin'}
+
+moduleclass = 'tools'


### PR DESCRIPTION
This needs to be improved. I am not sure how to resolve dependency on XCB (X11) library for GUI in the VNC container:
 
- Now it is taken from `X11` module but it is not resolved while `SINGULARITYENV_LD_LIBRARY_PATH` needs values to be evaluated and `$EBROOTX11` won't work; moreover it implicitly loads `cpeGNU` which may conflict with actual programming environment,
- XCB could be possibly added to the container but it contains 100+ libraries and may unnecessarily enlarge the container image
- XCB could be build with `system` toolchain but I am not sure if actually makes sense. 