### PR TITLE
Add OpenMPI recipe

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.2-cpeGNU-22.06.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.2-cpeGNU-22.06.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '4.1.2'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.06'}
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['a400719b04375cd704d2ed063a50e42d268497a3dfede342986ab7a8d7e8dcf0']
+
+dependencies = [
+    ('rocm/5.1.4', EXTERNAL_MODULE)
+]
+
+configopts = '--with-libfabric=/opt/cray/libfabric/1.15.0.0 '
+
+sanity_check_paths = {
+    'files': ['bin/ompi_info', 'bin/opal_wrapper', 'bin/orterun', 'lib/libmpi.so'],
+    'dirs': ['bin', 'lib', 'include'],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.2-cpeGNU-22.06.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.2-cpeGNU-22.06.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('rocm/5.1.4', EXTERNAL_MODULE)
 ]
 
-configopts = '--with-libfabric=/opt/cray/libfabric/1.15.0.0 '
+configopts = '--with-ofi=/opt/cray/libfabric/1.15.0.0 --with-pmi=/usr'
 
 sanity_check_paths = {
     'files': ['bin/ompi_info', 'bin/opal_wrapper', 'bin/orterun', 'lib/libmpi.so'],

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '4.1.3'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['9c0fd1f78fc90ca9b69ae4ab704687d5544220005ccd7678bf58cc13135e67e0']
+
+dependencies = [
+    ('rocm/5.0.2', EXTERNAL_MODULE)
+]
+
+configopts  = '--with-libfabric=/opt/cray/libfabric/$(pkg-config --modversion libfabric) '
+configopts += '--with-slurm '
+
+sanity_check_paths = {
+    'files': ['bin/ompi_info', 'bin/opal_wrapper', 'bin/orterun', 'lib/libmpi.so'],
+    'dirs': ['bin', 'lib', 'include'],
+}
+
+moduleclass = 'mpi'


### PR DESCRIPTION
This does a simple OpenMPI compilation mostly to launch containers with deep learning applications which will use RCCL as communication backend. I don't think we need to install it on the system. It can be installed locally by the users that needed.