### PR TITLE
Add easyconfig for hipSYCL-0.9.3

### DIFF
--- a/easybuild/easyconfigs/h/hipSYCL/hipSYCL-0.9.3-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/h/hipSYCL/hipSYCL-0.9.3-cpeGNU-22.08.eb
@@ -1,0 +1,48 @@
+easyblock = 'CMakeMake'
+
+name = 'hipSYCL'
+version = '0.9.3'
+
+homepage = 'https://github.com/illuhad/hipSYCL'
+description = """hipSYCL is a modern SYCL implementation targeting CPUs and
+GPUs, with a focus on leveraging existing toolchains such as CUDA or HIP"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'verbose': False, 'openmp': True}
+
+source_urls = ["https://github.com/illuhad/hipSYCL/archive/refs/tags/"]
+sources = ["v%(version)s.tar.gz"]
+checksums = ['65eb7d7302412741ddf912fc2f7e2e22d32686f3798d8489939158baad342d24']
+
+dependencies = [
+    ('Boost', '1.79.0'),
+    ('cray-python/3.9.12.1', EXTERNAL_MODULE),
+    ('rocm/5.0.2', EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '-DROCM_PATH=$ROCM_PATH '
+configopts += '-DWITH_ACCELERATED_CPU=OFF '
+configopts += '-DWITH_CPU_BACKEND=ON '
+configopts += '-DWITH_CUDA_BACKEND=OFF '
+configopts += '-DWITH_ROCM_BACKEND=ON '
+configopts += '-DDEFAULT_GPU_ARCH=gfx90a '
+
+sanity_check_paths = {
+    'files': ['bin/syclcc-clang', 'include/sycl/sycl.hpp',
+              'lib/hipSYCL/librt-backend-omp.%s' % SHLIB_EXT,
+              'lib/hipSYCL/librt-backend-hip.%s' % SHLIB_EXT,
+              'lib/libhipSYCL_clang.%s' % SHLIB_EXT,
+              'lib/libhipSYCL-rt.%s' % SHLIB_EXT],
+    'dirs': ['include/CL', 'include/hipSYCL', 'include/SYCL'],
+}
+sanity_check_commands = ['syclcc --help']
+
+modextravars = {
+    'HIPSYCL_TARGETS': 'hip:gfx90a',
+}
+
+moduleclass = 'compiler'


### PR DESCRIPTION
This receipt exports a default hipSYCL target for LUMI-G's GPUs.
Additionally, the accelerated CPU backend is disable due to
incompatibility between the ROCm version's LLVM and what hipSYCL
expects ([ref](https://github.com/illuhad/hipSYCL/blob/develop/doc/install-rocm.md)).