### PR TITLE
Add the `--with-pmi` flag to the configuration

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 configopts  = '--with-libfabric=/opt/cray/libfabric/$(pkg-config --modversion libfabric) '
-configopts += '--with-slurm '
+configopts += '--with-pmi=/usr '
 
 sanity_check_paths = {
     'files': ['bin/ompi_info', 'bin/opal_wrapper', 'bin/orterun', 'lib/libmpi.so'],


### PR DESCRIPTION
* I forgot to add `--with-pmi=/usr` in this version of the easyconfig
* `--with-slurm` is passed by default