### PR TITLE
OpenFOAM unify cxx abi

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-cpeGNU-21.08.eb
@@ -62,6 +62,7 @@ buildininstalldir = 'True'
 
 install_cmd  = "source etc/bashrc WM_COMPILER=Cray WM_MPLIB=CRAY-MPICH MPICH_DIR=${CRAY_MPICH_PREFIX} "
 install_cmd += "&& cp ./wmake/rules/General/cgal-no-mpfr ./wmake/rules/General/cgal "
+install_cmd += "&& export FOAM_EXTRA_CXXFLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' "  # This has to be set after sourcing etc/bashrc!
 install_cmd += "&& ./bin/tools/foamConfigurePaths -boost boost-system -boost-path ${EBROOTBOOST} -fftw fftw-system -fftw-path ${FFTW_ROOT} -scotch scotch-system -scotch-path ${EBROOTSCOTCH} -cgal cgal-system -cgal-path ${EBROOTCGAL} "
 install_cmd += "&& ./Allwmake -j 32"
 

--- a/easybuild/easyconfigs/o/OpenFOAM/wmake-rules-linux64Cray.patch
+++ b/easybuild/easyconfigs/o/OpenFOAM/wmake-rules-linux64Cray.patch
@@ -37,7 +37,7 @@ diff -Naur OpenFOAM-9-cpeGNU-21.08/wmake/rules/linux64Cray/c++ OpenFOAM-9/wmake/
 +
 +ptFLAGS     = -DNoRepository -ftemplate-depth-100
 +
-+c++FLAGS    = $(GFLAGS) $(c++WARN) $(c++OPT) $(c++DBUG) $(ptFLAGS) $(LIB_HEADER_DIRS) -fPIC
++c++FLAGS    = $(GFLAGS) $(c++WARN) $(c++OPT) $(c++DBUG) $(ptFLAGS) $(LIB_HEADER_DIRS) -fPIC -D_GLIBCXX_USE_CXX11_ABI=0
 +
 +Ctoo        = $(WM_SCHEDULER) $(CC) $(c++FLAGS) -c $< -o $@
 +cxxtoo      = $(Ctoo)


### PR DESCRIPTION
Force `_GLIBCXX_USE_CXX11_ABI=0` macro, for C++ ABI consistency, in both build script and wmake rules (for later user code support). Resolves #46.