### PR TITLE
Easyconfigs for latest ELPA release with GNU/Cray

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2022.05.001-cpeCray-22.08-CPU.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2022.05.001-cpeCray-22.08-CPU.eb
@@ -1,0 +1,67 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+easyblock = 'ConfigureMake'
+
+local_ELPA_version =           '2022.05.001'     # Synchronized with CSCS but also the version in EB 2021b
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-CPU'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://gitlab.mpcdf.mpg.de/elpa/elpa/-/archive/new_release_%(version)s/']
+sources =     ['elpa-new_release_%(version)s.tar.gz']
+patches =     ['ELPA_configure_manual_cpp.patch', 'sycl_and_mkl.patch']
+
+builddependencies = [ # We use the system Python and Perl.
+    ('buildtools', '%(toolchain_version)s', '', True), # For Autotools and others.
+]
+
+preconfigopts  = './autogen.sh && '
+preconfigopts += " CC=cc CXX=CC FC=ftn CPP=cpp && "
+
+local_commonopts = ' FCFLAGS="$FCFLAGS" CPP=cpp --disable-generic --disable-sse --disable-avx --enable-avx2 --disable-avx512 --enable-static '
+configopts = [
+    local_commonopts + ' --disable-openmp '
+]
+
+prebuildopts = " make clean && "
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules']
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s'
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2022.05.001-cpeGNU-22.08-CPU.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2022.05.001-cpeGNU-22.08-CPU.eb
@@ -1,0 +1,71 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+easyblock = 'ConfigureMake'
+
+local_ELPA_version =           '2022.05.001'     # Synchronized with CSCS but also the version in EB 2021b
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-CPU'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://gitlab.mpcdf.mpg.de/elpa/elpa/-/archive/new_release_%(version)s/']
+sources =     ['elpa-new_release_%(version)s.tar.gz']
+
+builddependencies = [ # We use the system Python and Perl.
+    ('buildtools', '%(toolchain_version)s', '', True), # For Autotools and others.
+#    ('cray-libsci', EXTERNAL_MODULE)
+]
+
+preconfigopts  = './autogen.sh && '
+preconfigopts += " CC=cc CXX=CC FC=ftn CPP=cpp && "
+
+local_commonopts = ' FCFLAGS="$FCFLAGS" CPP=cpp --disable-generic --disable-sse --disable-avx --enable-avx2 --disable-avx512 --enable-static '
+#local_libs = 'LIBS="-lsci_gnu" '
+configopts = [
+    local_commonopts + ' --enable-openmp ',
+    local_commonopts + ' --disable-openmp '
+]
+
+prebuildopts = " make clean && "
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so', 'lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules',
+              'include/%(namelower)s_openmp-%(version)s/%(namelower)s', 'include/%(namelower)s_openmp-%(version)s/modules']
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa_openmp-%(version)s', 'include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s',
+    'ELPA_OPENMP_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s'
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
These are for the latest ELPA release (2022.05.001) with GNU and Cray compilers. The configs are CPU only versions to build GPU (ROCm) enabled on top of them. GNU version is essentially copy of the Kurt's config for previous release.

Issues:
* Cray version requires patches to build (add manual preprocessing option to the configure script and remove some broken sycl code),
* OpenMP compilation causes Cray Fortran compiler to segfault (therefore there is only non openmp version)
* TODO: cpeAMD version 