### PR TITLE
Update spglib EB recipe

### DIFF
--- a/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-21.08.eb
@@ -6,7 +6,7 @@ easyblock = 'CMakeMake'
 name =    'spglib'
 version = '1.16.3'
 
-homepage = 'https://atztogo.github.io/spglib/'
+homepage = 'https://spglib.github.io/spglib/'
 
 whatis = [
     'Description: Spglib is a library for finding and handling crystal symmetries written in C'
@@ -23,7 +23,7 @@ docurls = [
 toolchain = {'name': 'cpeGNU', 'version': '21.08'}
 toolchainopts = {'openmp': True, 'usempi': False}
 
-source_urls = ['https://github.com/atztogo/%(name)s/archive/']
+source_urls = ['https://github.com/spglib/%(name)s/archive/']
 sources = ['v%(version)s.tar.gz']
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-21.12.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-21.12.eb
@@ -6,7 +6,7 @@ easyblock = 'CMakeMake'
 name =    'spglib'
 version = '1.16.3'
 
-homepage = 'https://atztogo.github.io/spglib/'
+homepage = 'https://spglib.github.io/spglib/'
 
 whatis = [
     'Description: Spglib is a library for finding and handling crystal symmetries written in C'
@@ -23,7 +23,7 @@ docurls = [
 toolchain = {'name': 'cpeGNU', 'version': '21.12'}
 toolchainopts = {'openmp': True, 'usempi': False}
 
-source_urls = ['https://github.com/atztogo/%(name)s/archive/']
+source_urls = ['https://github.com/spglib/%(name)s/archive/']
 sources = ['v%(version)s.tar.gz']
 
 builddependencies = [

--- a/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-22.08.eb
@@ -6,7 +6,7 @@ easyblock = 'CMakeMake'
 name =    'spglib'
 version = '1.16.3'
 
-homepage = 'https://atztogo.github.io/spglib/'
+homepage = 'https://spglib.github.io/spglib/'
 
 whatis = [
     'Description: Spglib is a library for finding and handling crystal symmetries written in C'
@@ -23,7 +23,7 @@ docurls = [
 toolchain = {'name': 'cpeGNU', 'version': '22.08'}
 toolchainopts = {'openmp': True, 'usempi': False}
 
-source_urls = ['https://github.com/atztogo/%(name)s/archive/']
+source_urls = ['https://github.com/spglib/%(name)s/archive/']
 sources = ['v%(version)s.tar.gz']
 
 builddependencies = [


### PR DESCRIPTION
Usage on CP2K EB recipe (cpeGNU 22.08) spglib was broken as it couldn't file the tarball. Upon further investigation it turns out that the url links to where spglib was being deployed had changed. The EB recipe has been updated to reflect this. 

Further testing with new EB in progress