### PR TITLE
Feature/PyFR for CPE 22.08

### DIFF
--- a/easybuild/easyconfigs/h/h5py/LICENSE.md
+++ b/easybuild/easyconfigs/h/h5py/LICENSE.md
@@ -1,0 +1,5 @@
+# h5py license information
+
+The h5py package is covered by a BSD 3-clause license, a copy
+of which can be found in the
+[LICENSE file in the GitHub repository](https://github.com/h5py/h5py/blob/master/LICENSE).

--- a/easybuild/easyconfigs/h/h5py/README.md
+++ b/easybuild/easyconfigs/h/h5py/README.md
@@ -1,0 +1,22 @@
+# h5py
+
+  * [h5py web site](https://www.h5py.org/)
+
+      * [h5py Documentation](https://docs.h5py.org/en/stable/)
+
+  * [h5py on GitHub](https://github.com/h5py/h5py)
+
+
+## EasyBuild
+
+  * [h5py support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/h/h5py)
+
+  * [h5py support in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/h/h5py)
+
+### Version 3.6.0 for CPE GNU 22.08
+
+  * Is taken from the CSCS repository
+
+### Version 3.7.0 for CPE 22.08
+
+  * Based on CSCS version with additional information added

--- a/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeAMD-22.08-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeAMD-22.08-parallel.eb
@@ -1,0 +1,56 @@
+easyblock = 'PythonPackage'
+
+name = 'h5py'
+version = '3.7.0'
+versionsuffix = '-parallel'
+
+local_wheel_version = '0.37.1'
+
+homepage = 'http://www.h5py.org/'
+
+whatis = [
+    'Description: the h5py package is a Pythonic interface to the HDF5 binary' 
+    'data format.'
+]
+
+description = """
+ The h5py package provides both a high- and low-level interface to the HDF5
+ library from Python. The low-level interface is intended to be a complete
+ wrapping of the HDF5 API, while the high-level component supports access to HDF5
+ files, datasets and groups using established Python and NumPy concepts.
+
+ A strong emphasis on automatic conversion between Python (Numpy) datatypes and
+ data structures and their HDF5 equivalents vastly simplifies the process of
+ reading and writing data from Python.
+"""
+
+docurls = ['https://docs.h5py.org/en/3.7.0/']
+software_license_urls = ['https://github.com/h5py/h5py/blob/master/LICENSE']
+
+toolchain = {'name': 'cpeAMD', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3']
+
+builddependencies = [
+    ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python',        EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+use_pip = True
+prebuildopts = preinstallopts = 'HDF5_MPI="ON" H5PY_SETUP_REQUIRES=0 '
+
+# sanity checks (import h5py) fails on login nodes (MPI not available)
+options = {'modulename': 'os'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s']
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeCray-22.08-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeCray-22.08-parallel.eb
@@ -1,0 +1,56 @@
+easyblock = 'PythonPackage'
+
+name = 'h5py'
+version = '3.7.0'
+versionsuffix = '-parallel'
+
+local_wheel_version = '0.37.1'
+
+homepage = 'http://www.h5py.org/'
+
+whatis = [
+    'Description: the h5py package is a Pythonic interface to the HDF5 binary' 
+    'data format.'
+]
+
+description = """
+ The h5py package provides both a high- and low-level interface to the HDF5
+ library from Python. The low-level interface is intended to be a complete
+ wrapping of the HDF5 API, while the high-level component supports access to HDF5
+ files, datasets and groups using established Python and NumPy concepts.
+
+ A strong emphasis on automatic conversion between Python (Numpy) datatypes and
+ data structures and their HDF5 equivalents vastly simplifies the process of
+ reading and writing data from Python.
+"""
+
+docurls = ['https://docs.h5py.org/en/3.7.0/']
+software_license_urls = ['https://github.com/h5py/h5py/blob/master/LICENSE']
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3']
+
+builddependencies = [
+    ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python',        EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+use_pip = True
+prebuildopts = preinstallopts = 'HDF5_MPI="ON" H5PY_SETUP_REQUIRES=0 '
+
+# sanity checks (import h5py) fails on login nodes (MPI not available)
+options = {'modulename': 'os'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s']
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeGNU-22.08-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-3.7.0-cpeGNU-22.08-parallel.eb
@@ -1,0 +1,56 @@
+easyblock = 'PythonPackage'
+
+name = 'h5py'
+version = '3.7.0'
+versionsuffix = '-parallel'
+
+local_wheel_version = '0.37.1'
+
+homepage = 'http://www.h5py.org/'
+
+whatis = [
+    'Description: the h5py package is a Pythonic interface to the HDF5 binary' 
+    'data format.'
+]
+
+description = """
+ The h5py package provides both a high- and low-level interface to the HDF5
+ library from Python. The low-level interface is intended to be a complete
+ wrapping of the HDF5 API, while the high-level component supports access to HDF5
+ files, datasets and groups using established Python and NumPy concepts.
+
+ A strong emphasis on automatic conversion between Python (Numpy) datatypes and
+ data structures and their HDF5 equivalents vastly simplifies the process of
+ reading and writing data from Python.
+"""
+
+docurls = ['https://docs.h5py.org/en/3.7.0/']
+software_license_urls = ['https://github.com/h5py/h5py/blob/master/LICENSE']
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3']
+
+builddependencies = [
+    ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python',        EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+use_pip = True
+prebuildopts = preinstallopts = 'HDF5_MPI="ON" H5PY_SETUP_REQUIRES=0 '
+
+# sanity checks (import h5py) fails on login nodes (MPI not available)
+options = {'modulename': 'os'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s']
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/l/libxsmm/LICENSE.md
+++ b/easybuild/easyconfigs/l/libxsmm/LICENSE.md
@@ -1,0 +1,5 @@
+# libxsmm license information.
+
+The libxsmm package is covered by a BSD 3-Clause license a copy of which 
+can be found in the
+[LICENSE.md file in the libxsmm GitHub repository](https://github.com/libxsmm/libxsmm/blob/main/LICENSE.md).

--- a/easybuild/easyconfigs/l/libxsmm/README.md
+++ b/easybuild/easyconfigs/l/libxsmm/README.md
@@ -17,3 +17,8 @@
 ### libxsmm 1.17 for cpeGNU 21.08
 
   * The EasyConfig is a direct port of the CSCS one.
+
+### libxsmm 29Dec22 for CPE 22.08
+
+  * Created for PyFR as it requires a recent version of libxsmm but no release
+    exists. Use the date of the commit as the version.

--- a/easybuild/easyconfigs/l/libxsmm/libxsmm-29Dec22-cpeCray-22.08.eb
+++ b/easybuild/easyconfigs/l/libxsmm/libxsmm-29Dec22-cpeCray-22.08.eb
@@ -1,0 +1,40 @@
+easyblock = 'MakeCp'
+
+name =    'libxsmm'
+version = '29Dec22'
+
+local_github_commit = '1dc041554645421be450a64f77a09575e427c584'
+
+homepage = 'https://readthedocs.org/projects/libxsmm'
+
+whatis = [
+    'Description: Library targeting Intel Architecture for specialized dense and sparse matrix operations, and deep learning primitives'
+]
+
+description = """
+Library targeting Intel Architecture for specialized dense and sparse matrix
+operations, and deep learning primitives.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/libxsmm/libxsmm/archive/']
+sources = ['%s.tar.gz' % local_github_commit]
+
+buildopts = "PREFIX=%(installdir)s CXX=CC CC=cc FC=ftn AVX=2 STATIC=0 BLAS=0 install"
+
+skipsteps = [
+    'configure',
+    'install'
+]
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.f', 'include/%(name)s.h', 'lib/%(name)s.so'],
+    'dirs': ['include', 'include/%(name)s', 'lib'],
+}
+
+moduleclass = 'chem'
+

--- a/easybuild/easyconfigs/l/libxsmm/libxsmm-29Dec22-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/l/libxsmm/libxsmm-29Dec22-cpeGNU-22.08.eb
@@ -1,0 +1,40 @@
+easyblock = 'MakeCp'
+
+name =    'libxsmm'
+version = '29Dec22'
+
+local_github_commit = '1dc041554645421be450a64f77a09575e427c584'
+
+homepage = 'https://readthedocs.org/projects/libxsmm'
+
+whatis = [
+    'Description: Library targeting Intel Architecture for specialized dense and sparse matrix operations, and deep learning primitives'
+]
+
+description = """
+Library targeting Intel Architecture for specialized dense and sparse matrix
+operations, and deep learning primitives.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/libxsmm/libxsmm/archive/']
+sources = ['%s.tar.gz' % local_github_commit]
+
+buildopts = "PREFIX=%(installdir)s CXX=CC CC=cc FC=ftn AVX=2 STATIC=0 BLAS=0 install"
+
+skipsteps = [
+    'configure',
+    'install'
+]
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.f', 'include/%(name)s.h', 'lib/%(name)s.so'],
+    'dirs': ['include', 'include/%(name)s', 'lib'],
+}
+
+moduleclass = 'chem'
+

--- a/easybuild/easyconfigs/m/Mako/LICENSE.md
+++ b/easybuild/easyconfigs/m/Mako/LICENSE.md
@@ -1,0 +1,8 @@
+# Mako license information
+
+Mako is covered by the [MIT License](https://opensource.org/licenses/mit-license.php).
+
+The precise license information with the proper copyrights for Mako can be found in 
+the [LICENSE file](https://github.com/sqlalchemy/mako/blob/main/LICENSE) and
+[AUTHORS file](https://github.com/sqlalchemy/mako/blob/main/AUTHORS), bvoth in the
+[Mako GitHub reppository](https://github.com/sqlalchemy/mako).

--- a/easybuild/easyconfigs/m/Mako/Mako-1.2.0-cpeAMD-22.08.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.2.0-cpeAMD-22.08.eb
@@ -25,7 +25,7 @@ calling and scoping semantics.
 docurls = ['https://docs.makotemplates.org/']
 software_license_urls = ['https://github.com/sqlalchemy/mako/blob/main/LICENSE']
 
-toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchain = {'name': 'cpeAMD', 'version': '22.08'}
 
 use_pip = True
 sanity_pip_check = False

--- a/easybuild/easyconfigs/m/Mako/Mako-1.2.0-cpeCray-22.08.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.2.0-cpeCray-22.08.eb
@@ -25,7 +25,7 @@ calling and scoping semantics.
 docurls = ['https://docs.makotemplates.org/']
 software_license_urls = ['https://github.com/sqlalchemy/mako/blob/main/LICENSE']
 
-toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
 
 use_pip = True
 sanity_pip_check = False

--- a/easybuild/easyconfigs/p/PyFR/LICENSE.md
+++ b/easybuild/easyconfigs/p/PyFR/LICENSE.md
@@ -1,0 +1,4 @@
+# PyFR license.
+
+The PyFR license can be found in the 
+[LICENSE file in the PyFR GitHub repository](https://github.com/PyFR/PyFR/blob/develop/LICENSE).

--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeAMD-22.08-GPU.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeAMD-22.08-GPU.eb
@@ -1,0 +1,129 @@
+# Created for LUMI by Orian Louant
+easyblock = 'PythonBundle'
+
+name = 'PyFR'
+version = '1.15.0'
+versionsuffix = '-GPU'
+
+local_wheel_version   = '0.37.1'
+local_Mako_version    = '1.2.0'
+local_h5py_version    = '3.7.0'
+local_METIS_version   = '5.1.0'
+
+local_flit_core_version         = '3.8.0'
+local_tomli_version             = '2.0.1'
+local_pathspec_version          = '0.10.2'
+local_hatchling_version         = '1.11.1'
+local_hatch_vcs_version         = '0.2.0'
+local_platformdirs_version      = '2.5.4'
+local_typing_extensions_version = '4.4.0'
+local_pytools_version           = '2022.1.12'
+local_GiMMiK_version            = '3.0'
+
+local_flit_core_checksum         = 'b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3'
+local_tomli_checksum             = 'de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f'
+local_pathspec_checksum          = '8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0'
+local_hatchling_checksum         = '9f84361f70cf3a7ab9543b0c3ecc64211ed2ba8a606a71eb6a473c1c9b08e1d0'
+local_hatch_vcs_checksum         = '9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff'
+local_platformdirs_checksum      = '1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7'
+local_typing_extensions_checksum = '1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa'
+local_pytools_checksum           = '4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4'
+local_GiMMiK_checksum            = '49c3574d815acdc88625b7a8660c6d1f0a643a0353cfc65f6ccee04da05a2611'
+local_PyFR_checksum              = 'f3b916a42ff54d4a246107f32ddac53f2cd8217ecb139d857b3870f615ac7793'
+
+homepage = 'https://www.pyfr.org/'
+
+whatis = ['Description: PyFR is a framework for solving advection-diffusion type problems']
+
+description = """
+ PyFR is an open-source Python based framework for solving advection-diffusion
+ type problems on streaming architectures using the Flux Reconstruction approach
+ of Huynh. The framework is designed to solve a range of governing systems on
+ mixed unstructured grids containing various element types. It is also designed
+ to target a range of hardware platforms via use of an in-built domain specific
+ language derived from the Mako templating engine. PyFR has the following 
+ capabilities:
+ 
+  - Governing Equations - Euler, Navier Stokes
+  - Dimensionality - 2D, 3D
+  - Element Types - Triangles, Quadrilaterals, Hexahedra, Prisms, Tetrahedra, Pyramids
+  - Platforms - CPU Clusters, Nvidia GPU Clusters, AMD GPU Clusters
+  - Spatial Discretisation - High-Order Flux Reconstruction
+  - Temporal Discretisation - Explicit and Implicit (via Dual Time-Stepping)
+  - Precision - Single, Double
+  - Mesh Files Imported - Gmsh (.msh)
+  - Solution Files Exported - Unstructured VTK (.vtu, .pvtu)
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+  ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Mako',        local_Mako_version),
+    ('h5py',        local_h5py_version, '-parallel'),
+    ('METIS',       local_METIS_version),
+    ('rocm',        EXTERNAL_MODULE),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'use_pip_for_deps':  False,
+    'download_dep_fail': True,
+    'sanity_pip_check': False,
+}
+
+exts_list = [
+    ('flit-core', local_flit_core_version, {
+        'source_tmpl' : 'flit_core-%s.tar.gz' % local_flit_core_version,
+        'checksums'   : [local_flit_core_checksum],
+    }),
+    ('tomli', local_tomli_version, {
+        'checksums' : [local_tomli_checksum],
+    }),
+    ('pathspec', local_pathspec_version, {
+        'checksums' : [local_pathspec_checksum],
+    }),
+    ('hatchling', local_hatchling_version, {
+        'checksums' : [local_hatchling_checksum],
+    }),
+    ('hatch-vcs', local_hatch_vcs_version, {
+        'source_tmpl' : 'hatch_vcs-%s.tar.gz' % local_hatch_vcs_version,
+        'checksums'   : [local_hatch_vcs_checksum],
+    }),
+    ('platformdirs', local_platformdirs_version, {
+        'checksums' : [local_platformdirs_checksum],
+    }),
+    ('typing-extensions', local_typing_extensions_version, {
+        'source_tmpl' : 'typing_extensions-%s.tar.gz' % local_typing_extensions_version,
+        'checksums'   : [local_typing_extensions_checksum],
+    }),
+    ('pytools', local_pytools_version, {
+        'checksums' : [local_pytools_checksum],
+    }),
+    ('GiMMiK', local_GiMMiK_version, {
+        'source_tmpl' : 'v%s.tar.gz' % local_GiMMiK_version,
+        'source_urls' : ['https://github.com/PyFR/GiMMiK/archive/refs/tags/'],
+        'checksums'   : [local_GiMMiK_checksum],
+    }),
+    (name, version, {
+        'source_tmpl' : 'v%(version)s.tar.gz',
+        'source_urls' : ['https://github.com/PyFR/PyFR/archive/refs/tags/'],
+        'checksums'   : [local_PyFR_checksum],
+    }),
+]
+
+postinstallcmds = [
+    'sed -i "168d" %(installdir)s/lib/python%(pyshortver)s/site-packages/pyfr/backends/hip/driver.py',
+]
+
+modluafooter = """
+setenv("PYFR_METIS_LIBRARY_PATH", pathJoin(os.getenv("EBROOTMETIS"), "lib/libmetis.so"))
+"""
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeCray-22.08-CPU.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeCray-22.08-CPU.eb
@@ -1,0 +1,127 @@
+# Created for LUMI by Orian Louant
+easyblock = 'PythonBundle'
+
+name = 'PyFR'
+version = '1.15.0'
+versionsuffix = '-CPU'
+
+local_wheel_version   = '0.37.1'
+local_Mako_version    = '1.2.0'
+local_h5py_version    = '3.7.0'
+local_METIS_version   = '5.1.0'
+local_libxsmm_version = '29Dec22'
+
+local_flit_core_version         = '3.8.0'
+local_tomli_version             = '2.0.1'
+local_pathspec_version          = '0.10.2'
+local_hatchling_version         = '1.11.1'
+local_hatch_vcs_version         = '0.2.0'
+local_platformdirs_version      = '2.5.4'
+local_typing_extensions_version = '4.4.0'
+local_pytools_version           = '2022.1.12'
+local_GiMMiK_version            = '3.0'
+
+local_flit_core_checksum         = 'b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3'
+local_tomli_checksum             = 'de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f'
+local_pathspec_checksum          = '8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0'
+local_hatchling_checksum         = '9f84361f70cf3a7ab9543b0c3ecc64211ed2ba8a606a71eb6a473c1c9b08e1d0'
+local_hatch_vcs_checksum         = '9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff'
+local_platformdirs_checksum      = '1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7'
+local_typing_extensions_checksum = '1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa'
+local_pytools_checksum           = '4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4'
+local_GiMMiK_checksum            = '49c3574d815acdc88625b7a8660c6d1f0a643a0353cfc65f6ccee04da05a2611'
+local_PyFR_checksum              = 'f3b916a42ff54d4a246107f32ddac53f2cd8217ecb139d857b3870f615ac7793'
+
+homepage = 'https://www.pyfr.org/'
+
+whatis = ['Description: PyFR is a framework for solving advection-diffusion type problems']
+
+description = """
+ PyFR is an open-source Python based framework for solving advection-diffusion
+ type problems on streaming architectures using the Flux Reconstruction approach
+ of Huynh. The framework is designed to solve a range of governing systems on
+ mixed unstructured grids containing various element types. It is also designed
+ to target a range of hardware platforms via use of an in-built domain specific
+ language derived from the Mako templating engine. PyFR has the following 
+ capabilities:
+ 
+  - Governing Equations - Euler, Navier Stokes
+  - Dimensionality - 2D, 3D
+  - Element Types - Triangles, Quadrilaterals, Hexahedra, Prisms, Tetrahedra, Pyramids
+  - Platforms - CPU Clusters, Nvidia GPU Clusters, AMD GPU Clusters
+  - Spatial Discretisation - High-Order Flux Reconstruction
+  - Temporal Discretisation - Explicit and Implicit (via Dual Time-Stepping)
+  - Precision - Single, Double
+  - Mesh Files Imported - Gmsh (.msh)
+  - Solution Files Exported - Unstructured VTK (.vtu, .pvtu)
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+  ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Mako',        local_Mako_version),
+    ('h5py',        local_h5py_version, '-parallel'),
+    ('libxsmm',     local_libxsmm_version),
+    ('METIS',       local_METIS_version),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'use_pip_for_deps':  False,
+    'download_dep_fail': True,
+    'sanity_pip_check': False,
+}
+
+exts_list = [
+    ('flit-core', local_flit_core_version, {
+        'source_tmpl' : 'flit_core-%s.tar.gz' % local_flit_core_version,
+        'checksums'   : [local_flit_core_checksum],
+    }),
+    ('tomli', local_tomli_version, {
+        'checksums' : [local_tomli_checksum],
+    }),
+    ('pathspec', local_pathspec_version, {
+        'checksums' : [local_pathspec_checksum],
+    }),
+    ('hatchling', local_hatchling_version, {
+        'checksums' : [local_hatchling_checksum],
+    }),
+    ('hatch-vcs', local_hatch_vcs_version, {
+        'source_tmpl' : 'hatch_vcs-%s.tar.gz' % local_hatch_vcs_version,
+        'checksums'   : [local_hatch_vcs_checksum],
+    }),
+    ('platformdirs', local_platformdirs_version, {
+        'checksums' : [local_platformdirs_checksum],
+    }),
+    ('typing-extensions', local_typing_extensions_version, {
+        'source_tmpl' : 'typing_extensions-%s.tar.gz' % local_typing_extensions_version,
+        'checksums'   : [local_typing_extensions_checksum],
+    }),
+    ('pytools', local_pytools_version, {
+        'checksums' : [local_pytools_checksum],
+    }),
+    ('GiMMiK', local_GiMMiK_version, {
+        'source_tmpl' : 'v%s.tar.gz' % local_GiMMiK_version,
+        'source_urls' : ['https://github.com/PyFR/GiMMiK/archive/refs/tags/'],
+        'checksums'   : [local_GiMMiK_checksum],
+    }),
+    (name, version, {
+        'source_tmpl' : 'v%(version)s.tar.gz',
+        'source_urls' : ['https://github.com/PyFR/PyFR/archive/refs/tags/'],
+        'checksums'   : [local_PyFR_checksum],
+    }),
+]
+
+modluafooter = """
+setenv("PYFR_XSMM_LIBRARY_PATH", pathJoin(os.getenv("EBROOTLIBXSMM"), "lib/libxsmm.so"))
+setenv("PYFR_METIS_LIBRARY_PATH", pathJoin(os.getenv("EBROOTMETIS"), "lib/libmetis.so"))
+"""
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeCray-22.08-GPU.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeCray-22.08-GPU.eb
@@ -1,0 +1,129 @@
+# Created for LUMI by Orian Louant
+easyblock = 'PythonBundle'
+
+name = 'PyFR'
+version = '1.15.0'
+versionsuffix = '-GPU'
+
+local_wheel_version   = '0.37.1'
+local_Mako_version    = '1.2.0'
+local_h5py_version    = '3.7.0'
+local_METIS_version   = '5.1.0'
+
+local_flit_core_version         = '3.8.0'
+local_tomli_version             = '2.0.1'
+local_pathspec_version          = '0.10.2'
+local_hatchling_version         = '1.11.1'
+local_hatch_vcs_version         = '0.2.0'
+local_platformdirs_version      = '2.5.4'
+local_typing_extensions_version = '4.4.0'
+local_pytools_version           = '2022.1.12'
+local_GiMMiK_version            = '3.0'
+
+local_flit_core_checksum         = 'b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3'
+local_tomli_checksum             = 'de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f'
+local_pathspec_checksum          = '8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0'
+local_hatchling_checksum         = '9f84361f70cf3a7ab9543b0c3ecc64211ed2ba8a606a71eb6a473c1c9b08e1d0'
+local_hatch_vcs_checksum         = '9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff'
+local_platformdirs_checksum      = '1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7'
+local_typing_extensions_checksum = '1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa'
+local_pytools_checksum           = '4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4'
+local_GiMMiK_checksum            = '49c3574d815acdc88625b7a8660c6d1f0a643a0353cfc65f6ccee04da05a2611'
+local_PyFR_checksum              = 'f3b916a42ff54d4a246107f32ddac53f2cd8217ecb139d857b3870f615ac7793'
+
+homepage = 'https://www.pyfr.org/'
+
+whatis = ['Description: PyFR is a framework for solving advection-diffusion type problems']
+
+description = """
+ PyFR is an open-source Python based framework for solving advection-diffusion
+ type problems on streaming architectures using the Flux Reconstruction approach
+ of Huynh. The framework is designed to solve a range of governing systems on
+ mixed unstructured grids containing various element types. It is also designed
+ to target a range of hardware platforms via use of an in-built domain specific
+ language derived from the Mako templating engine. PyFR has the following 
+ capabilities:
+ 
+  - Governing Equations - Euler, Navier Stokes
+  - Dimensionality - 2D, 3D
+  - Element Types - Triangles, Quadrilaterals, Hexahedra, Prisms, Tetrahedra, Pyramids
+  - Platforms - CPU Clusters, Nvidia GPU Clusters, AMD GPU Clusters
+  - Spatial Discretisation - High-Order Flux Reconstruction
+  - Temporal Discretisation - Explicit and Implicit (via Dual Time-Stepping)
+  - Precision - Single, Double
+  - Mesh Files Imported - Gmsh (.msh)
+  - Solution Files Exported - Unstructured VTK (.vtu, .pvtu)
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+  ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Mako',        local_Mako_version),
+    ('h5py',        local_h5py_version, '-parallel'),
+    ('METIS',       local_METIS_version),
+    ('rocm',        EXTERNAL_MODULE),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'use_pip_for_deps':  False,
+    'download_dep_fail': True,
+    'sanity_pip_check': False,
+}
+
+exts_list = [
+    ('flit-core', local_flit_core_version, {
+        'source_tmpl' : 'flit_core-%s.tar.gz' % local_flit_core_version,
+        'checksums'   : [local_flit_core_checksum],
+    }),
+    ('tomli', local_tomli_version, {
+        'checksums' : [local_tomli_checksum],
+    }),
+    ('pathspec', local_pathspec_version, {
+        'checksums' : [local_pathspec_checksum],
+    }),
+    ('hatchling', local_hatchling_version, {
+        'checksums' : [local_hatchling_checksum],
+    }),
+    ('hatch-vcs', local_hatch_vcs_version, {
+        'source_tmpl' : 'hatch_vcs-%s.tar.gz' % local_hatch_vcs_version,
+        'checksums'   : [local_hatch_vcs_checksum],
+    }),
+    ('platformdirs', local_platformdirs_version, {
+        'checksums' : [local_platformdirs_checksum],
+    }),
+    ('typing-extensions', local_typing_extensions_version, {
+        'source_tmpl' : 'typing_extensions-%s.tar.gz' % local_typing_extensions_version,
+        'checksums'   : [local_typing_extensions_checksum],
+    }),
+    ('pytools', local_pytools_version, {
+        'checksums' : [local_pytools_checksum],
+    }),
+    ('GiMMiK', local_GiMMiK_version, {
+        'source_tmpl' : 'v%s.tar.gz' % local_GiMMiK_version,
+        'source_urls' : ['https://github.com/PyFR/GiMMiK/archive/refs/tags/'],
+        'checksums'   : [local_GiMMiK_checksum],
+    }),
+    (name, version, {
+        'source_tmpl' : 'v%(version)s.tar.gz',
+        'source_urls' : ['https://github.com/PyFR/PyFR/archive/refs/tags/'],
+        'checksums'   : [local_PyFR_checksum],
+    }),
+]
+
+postinstallcmds = [
+    'sed -i "168d" %(installdir)s/lib/python%(pyshortver)s/site-packages/pyfr/backends/hip/driver.py',
+]
+
+modluafooter = """
+setenv("PYFR_METIS_LIBRARY_PATH", pathJoin(os.getenv("EBROOTMETIS"), "lib/libmetis.so"))
+"""
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeGNU-22.08-CPU.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeGNU-22.08-CPU.eb
@@ -1,0 +1,127 @@
+# Created for LUMI by Orian Louant
+easyblock = 'PythonBundle'
+
+name = 'PyFR'
+version = '1.15.0'
+versionsuffix = '-CPU'
+
+local_wheel_version   = '0.37.1'
+local_Mako_version    = '1.2.0'
+local_h5py_version    = '3.7.0'
+local_METIS_version   = '5.1.0'
+local_libxsmm_version = '29Dec22'
+
+local_flit_core_version         = '3.8.0'
+local_tomli_version             = '2.0.1'
+local_pathspec_version          = '0.10.2'
+local_hatchling_version         = '1.11.1'
+local_hatch_vcs_version         = '0.2.0'
+local_platformdirs_version      = '2.5.4'
+local_typing_extensions_version = '4.4.0'
+local_pytools_version           = '2022.1.12'
+local_GiMMiK_version            = '3.0'
+
+local_flit_core_checksum         = 'b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3'
+local_tomli_checksum             = 'de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f'
+local_pathspec_checksum          = '8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0'
+local_hatchling_checksum         = '9f84361f70cf3a7ab9543b0c3ecc64211ed2ba8a606a71eb6a473c1c9b08e1d0'
+local_hatch_vcs_checksum         = '9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff'
+local_platformdirs_checksum      = '1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7'
+local_typing_extensions_checksum = '1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa'
+local_pytools_checksum           = '4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4'
+local_GiMMiK_checksum            = '49c3574d815acdc88625b7a8660c6d1f0a643a0353cfc65f6ccee04da05a2611'
+local_PyFR_checksum              = 'f3b916a42ff54d4a246107f32ddac53f2cd8217ecb139d857b3870f615ac7793'
+
+homepage = 'https://www.pyfr.org/'
+
+whatis = ['Description: PyFR is a framework for solving advection-diffusion type problems']
+
+description = """
+ PyFR is an open-source Python based framework for solving advection-diffusion
+ type problems on streaming architectures using the Flux Reconstruction approach
+ of Huynh. The framework is designed to solve a range of governing systems on
+ mixed unstructured grids containing various element types. It is also designed
+ to target a range of hardware platforms via use of an in-built domain specific
+ language derived from the Mako templating engine. PyFR has the following 
+ capabilities:
+ 
+  - Governing Equations - Euler, Navier Stokes
+  - Dimensionality - 2D, 3D
+  - Element Types - Triangles, Quadrilaterals, Hexahedra, Prisms, Tetrahedra, Pyramids
+  - Platforms - CPU Clusters, Nvidia GPU Clusters, AMD GPU Clusters
+  - Spatial Discretisation - High-Order Flux Reconstruction
+  - Temporal Discretisation - Explicit and Implicit (via Dual Time-Stepping)
+  - Precision - Single, Double
+  - Mesh Files Imported - Gmsh (.msh)
+  - Solution Files Exported - Unstructured VTK (.vtu, .pvtu)
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+  ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Mako',        local_Mako_version),
+    ('h5py',        local_h5py_version, '-parallel'),
+    ('libxsmm',     local_libxsmm_version),
+    ('METIS',       local_METIS_version),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'use_pip_for_deps':  False,
+    'download_dep_fail': True,
+    'sanity_pip_check': False,
+}
+
+exts_list = [
+    ('flit-core', local_flit_core_version, {
+        'source_tmpl' : 'flit_core-%s.tar.gz' % local_flit_core_version,
+        'checksums'   : [local_flit_core_checksum],
+    }),
+    ('tomli', local_tomli_version, {
+        'checksums' : [local_tomli_checksum],
+    }),
+    ('pathspec', local_pathspec_version, {
+        'checksums' : [local_pathspec_checksum],
+    }),
+    ('hatchling', local_hatchling_version, {
+        'checksums' : [local_hatchling_checksum],
+    }),
+    ('hatch-vcs', local_hatch_vcs_version, {
+        'source_tmpl' : 'hatch_vcs-%s.tar.gz' % local_hatch_vcs_version,
+        'checksums'   : [local_hatch_vcs_checksum],
+    }),
+    ('platformdirs', local_platformdirs_version, {
+        'checksums' : [local_platformdirs_checksum],
+    }),
+    ('typing-extensions', local_typing_extensions_version, {
+        'source_tmpl' : 'typing_extensions-%s.tar.gz' % local_typing_extensions_version,
+        'checksums'   : [local_typing_extensions_checksum],
+    }),
+    ('pytools', local_pytools_version, {
+        'checksums' : [local_pytools_checksum],
+    }),
+    ('GiMMiK', local_GiMMiK_version, {
+        'source_tmpl' : 'v%s.tar.gz' % local_GiMMiK_version,
+        'source_urls' : ['https://github.com/PyFR/GiMMiK/archive/refs/tags/'],
+        'checksums'   : [local_GiMMiK_checksum],
+    }),
+    (name, version, {
+        'source_tmpl' : 'v%(version)s.tar.gz',
+        'source_urls' : ['https://github.com/PyFR/PyFR/archive/refs/tags/'],
+        'checksums'   : [local_PyFR_checksum],
+    }),
+]
+
+modluafooter = """
+setenv("PYFR_XSMM_LIBRARY_PATH", pathJoin(os.getenv("EBROOTLIBXSMM"), "lib/libxsmm.so"))
+setenv("PYFR_METIS_LIBRARY_PATH", pathJoin(os.getenv("EBROOTMETIS"), "lib/libmetis.so"))
+"""
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeGNU-22.08-GPU.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.15.0-cpeGNU-22.08-GPU.eb
@@ -1,0 +1,129 @@
+# Created for LUMI by Orian Louant
+easyblock = 'PythonBundle'
+
+name = 'PyFR'
+version = '1.15.0'
+versionsuffix = '-GPU'
+
+local_wheel_version   = '0.37.1'
+local_Mako_version    = '1.2.0'
+local_h5py_version    = '3.7.0'
+local_METIS_version   = '5.1.0'
+
+local_flit_core_version         = '3.8.0'
+local_tomli_version             = '2.0.1'
+local_pathspec_version          = '0.10.2'
+local_hatchling_version         = '1.11.1'
+local_hatch_vcs_version         = '0.2.0'
+local_platformdirs_version      = '2.5.4'
+local_typing_extensions_version = '4.4.0'
+local_pytools_version           = '2022.1.12'
+local_GiMMiK_version            = '3.0'
+
+local_flit_core_checksum         = 'b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3'
+local_tomli_checksum             = 'de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f'
+local_pathspec_checksum          = '8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0'
+local_hatchling_checksum         = '9f84361f70cf3a7ab9543b0c3ecc64211ed2ba8a606a71eb6a473c1c9b08e1d0'
+local_hatch_vcs_checksum         = '9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff'
+local_platformdirs_checksum      = '1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7'
+local_typing_extensions_checksum = '1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa'
+local_pytools_checksum           = '4d62875e9a2ab2a24e393a9a8b799492f1a721bffa840af3807bfd42871dd1f4'
+local_GiMMiK_checksum            = '49c3574d815acdc88625b7a8660c6d1f0a643a0353cfc65f6ccee04da05a2611'
+local_PyFR_checksum              = 'f3b916a42ff54d4a246107f32ddac53f2cd8217ecb139d857b3870f615ac7793'
+
+homepage = 'https://www.pyfr.org/'
+
+whatis = ['Description: PyFR is a framework for solving advection-diffusion type problems']
+
+description = """
+ PyFR is an open-source Python based framework for solving advection-diffusion
+ type problems on streaming architectures using the Flux Reconstruction approach
+ of Huynh. The framework is designed to solve a range of governing systems on
+ mixed unstructured grids containing various element types. It is also designed
+ to target a range of hardware platforms via use of an in-built domain specific
+ language derived from the Mako templating engine. PyFR has the following 
+ capabilities:
+ 
+  - Governing Equations - Euler, Navier Stokes
+  - Dimensionality - 2D, 3D
+  - Element Types - Triangles, Quadrilaterals, Hexahedra, Prisms, Tetrahedra, Pyramids
+  - Platforms - CPU Clusters, Nvidia GPU Clusters, AMD GPU Clusters
+  - Spatial Discretisation - High-Order Flux Reconstruction
+  - Temporal Discretisation - Explicit and Implicit (via Dual Time-Stepping)
+  - Precision - Single, Double
+  - Mesh Files Imported - Gmsh (.msh)
+  - Solution Files Exported - Unstructured VTK (.vtu, .pvtu)
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchainopts = {'usempi': True}
+
+builddependencies = [
+  ('wheel', local_wheel_version, '-cray-python%(pyshortver)s')
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Mako',        local_Mako_version),
+    ('h5py',        local_h5py_version, '-parallel'),
+    ('METIS',       local_METIS_version),
+    ('rocm',        EXTERNAL_MODULE),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'use_pip_for_deps':  False,
+    'download_dep_fail': True,
+    'sanity_pip_check': False,
+}
+
+exts_list = [
+    ('flit-core', local_flit_core_version, {
+        'source_tmpl' : 'flit_core-%s.tar.gz' % local_flit_core_version,
+        'checksums'   : [local_flit_core_checksum],
+    }),
+    ('tomli', local_tomli_version, {
+        'checksums' : [local_tomli_checksum],
+    }),
+    ('pathspec', local_pathspec_version, {
+        'checksums' : [local_pathspec_checksum],
+    }),
+    ('hatchling', local_hatchling_version, {
+        'checksums' : [local_hatchling_checksum],
+    }),
+    ('hatch-vcs', local_hatch_vcs_version, {
+        'source_tmpl' : 'hatch_vcs-%s.tar.gz' % local_hatch_vcs_version,
+        'checksums'   : [local_hatch_vcs_checksum],
+    }),
+    ('platformdirs', local_platformdirs_version, {
+        'checksums' : [local_platformdirs_checksum],
+    }),
+    ('typing-extensions', local_typing_extensions_version, {
+        'source_tmpl' : 'typing_extensions-%s.tar.gz' % local_typing_extensions_version,
+        'checksums'   : [local_typing_extensions_checksum],
+    }),
+    ('pytools', local_pytools_version, {
+        'checksums' : [local_pytools_checksum],
+    }),
+    ('GiMMiK', local_GiMMiK_version, {
+        'source_tmpl' : 'v%s.tar.gz' % local_GiMMiK_version,
+        'source_urls' : ['https://github.com/PyFR/GiMMiK/archive/refs/tags/'],
+        'checksums'   : [local_GiMMiK_checksum],
+    }),
+    (name, version, {
+        'source_tmpl' : 'v%(version)s.tar.gz',
+        'source_urls' : ['https://github.com/PyFR/PyFR/archive/refs/tags/'],
+        'checksums'   : [local_PyFR_checksum],
+    }),
+]
+
+postinstallcmds = [
+    'sed -i "168d" %(installdir)s/lib/python%(pyshortver)s/site-packages/pyfr/backends/hip/driver.py',
+]
+
+modluafooter = """
+setenv("PYFR_METIS_LIBRARY_PATH", pathJoin(os.getenv("EBROOTMETIS"), "lib/libmetis.so"))
+"""
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/p/PyFR/README.md
+++ b/easybuild/easyconfigs/p/PyFR/README.md
@@ -9,9 +9,10 @@
 
 ## EasyBuild
 
-  * [h5py support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/PyFR)
+  * [PyFR support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/PyFR)
 
-  * [h5py support in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/p/PyFR)
+  * [PyFR support in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/p/PyFR)
+
 
 ### Version 1.15.0 for CPE GNU 22.08
 

--- a/easybuild/easyconfigs/p/PyFR/README.md
+++ b/easybuild/easyconfigs/p/PyFR/README.md
@@ -1,0 +1,18 @@
+# PyFR
+
+  * [PyFR web site](https://www.pyfr.org/)
+
+      * [PyFR Documentation](https://pyfr.readthedocs.io/en/latest/)
+
+  * [PyFR on GitHub](https://github.com/PyFR/PyFR)
+
+
+## EasyBuild
+
+  * [h5py support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/PyFR)
+
+  * [h5py support in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/p/PyFR)
+
+### Version 1.15.0 for CPE GNU 22.08
+
+  * Created from scratch for LUMI

--- a/easybuild/easyconfigs/w/wheel/LICENSE.md
+++ b/easybuild/easyconfigs/w/wheel/LICENSE.md
@@ -1,0 +1,5 @@
+# Wheel license
+
+The wheel package is covered by an MIT License. 
+The exact license for wheel can be found in the
+[LICENSE.txt file in the wheel GitHub repository](https://github.com/pypa/wheel/blob/main/LICENSE.txt).

--- a/easybuild/easyconfigs/w/wheel/wheel-0.37.1-cpeAMD-22.08-cray-python3.9.eb
+++ b/easybuild/easyconfigs/w/wheel/wheel-0.37.1-cpeAMD-22.08-cray-python3.9.eb
@@ -27,7 +27,7 @@ description = """
 docurls = ['https://wheel.readthedocs.io/en/stable/']
 software_license_urls = ['https://github.com/pypa/wheel/blob/main/LICENSE.txt']
 
-toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchain = {'name': 'cpeAMD', 'version': '22.08'}
 
 sources = [SOURCE_TAR_GZ]
 checksums = ['e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4']

--- a/easybuild/easyconfigs/w/wheel/wheel-0.37.1-cpeCray-22.08-cray-python3.9.eb
+++ b/easybuild/easyconfigs/w/wheel/wheel-0.37.1-cpeCray-22.08-cray-python3.9.eb
@@ -27,7 +27,7 @@ description = """
 docurls = ['https://wheel.readthedocs.io/en/stable/']
 software_license_urls = ['https://github.com/pypa/wheel/blob/main/LICENSE.txt']
 
-toolchain = {'name': 'cpeGNU', 'version': '22.08'}
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
 
 sources = [SOURCE_TAR_GZ]
 checksums = ['e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4']


### PR DESCRIPTION
PyFR for CPE 22.08 that include

- CPU version  (CPU suffix) for cpeCray and cpeGNU using the libxsmm OpenMP backend. PyFR requires a recent version of libxsmm for which no release exists, the date of the commit is used as the version.
- GPU version (GPU suffix) for cpeCray, cpeGNU and cpeAMD

Requested by RT#1284