### PR TITLE
Clarify Amber license and usage info

### DIFF
--- a/easybuild/easyconfigs/a/Amber/LICENSE.md
+++ b/easybuild/easyconfigs/a/Amber/LICENSE.md
@@ -1,10 +1,8 @@
 # Amber license information
 
-Amber is licensed software. In principle all academic use of Amber is covered by the
-CSC license, also for non-Finnish academic users, but as we have no way to limit
-access to only those users, for now Amber needs to be installed in your project
-space and users need their own license for now to download the right version of
-Amber.
+Amber is licensed software. All *academic* use of Amber is covered by the
+CSC license, also for non-Finnish academic users. See more details in the
+[CSC documentation](https://docs.csc.fi/apps/amber/).
 
 AmberTools is free software distributed under the GNU General Public License with a
 few components licensed differently. Amber itself has a separate license though.

--- a/easybuild/easyconfigs/a/Amber/README.md
+++ b/easybuild/easyconfigs/a/Amber/README.md
@@ -42,7 +42,7 @@ has to be downloaded separately.
 
 -   When installing using this EasyConfig, the user should provide the
     `Amber22.tar.bz2` , `AmberTools22.tar.bz2` and `amber_amd.23jun22.tar.bz2` files
-    n a place where EasyBuild can find them
+    in a place where EasyBuild can find them
     (e.g., in the current directory if you add `-r .` to the EasyBuild command line, or you can
     look for the first directory in `$EASYBUILD_SOURCEPATH`, create the subdirectory
     `a/Amber` in that directory and put the source files in that `a/Amber` subdirectory).

--- a/easybuild/easyconfigs/a/Amber/USER.md
+++ b/easybuild/easyconfigs/a/Amber/USER.md
@@ -1,14 +1,17 @@
-# Amber user instructions.
+# Amber user instructions
 
-As we currently have no way to limit access to the source files (or a pre-installed
-version of Amber for that reason) to users who have the right to use Amber on LUMI,
-users will need their own license for the right version of Amber and download the 
-source files to install Amber in your project space. 
+Users who have their own Amber license can download and install the software for
+themselves in their project space. In additon to this, a pre-installation maintained
+and supported by CSC is available under `/appl/local/csc`. For usage instructions,
+see the [CSC documentation](https://docs.csc.fi/apps/amber/). **Note that the CSC
+license allows only academic use by not-for-profit institutes and universities**.
+
 See also the instructions in the technical documentation further down
 the Amber page in the LUMI Software Library.
 
 AmberTools is free but it still requires a registration to download the source files
-which is why those need to be downloaded manually also at the moment.
+which is why those need to be downloaded manually also at the moment if you intend
+to install the software yourself.
 
 We are interested in feedback, especially for the GPU version, where AMD developed the
 port.


### PR DESCRIPTION
To clarify that users are allowed to use CSC's Amber license for academic use.