### PR TITLE
QUDA library for ROCm 5.3+

### DIFF
--- a/easybuild/easyconfigs/q/QUDA/QUDA-0a31b22-cpeAMD-22.09-GPU.eb
+++ b/easybuild/easyconfigs/q/QUDA/QUDA-0a31b22-cpeAMD-22.09-GPU.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
 name = 'QUDA'
-version = '25102022'
+version = '0a31b22'
 versionsuffix = "-GPU"
 
 homepage = 'https://lattice.github.io/quda/'
@@ -9,7 +9,7 @@ homepage = 'https://lattice.github.io/quda/'
 description = """QUDA is a library for performing calculations in lattice QCD on GPUs."""
 
 
-toolchain = {'name': 'cpeAMD', 'version': '22.08'}
+toolchain = {'name': 'cpeAMD', 'version': '23.09'}
 toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'strict': True}
 
 sources = [{
@@ -21,22 +21,30 @@ sources = [{
     }
 }]
 
-builddependencies = [
-    ('rocm',   EXTERNAL_MODULE),
-    ('buildtools',   '%(toolchain_version)s',   '', True),
-    ('cray-libsci',   EXTERNAL_MODULE),
+dependencies = [
+    ('amd', '5.6.1', '', SYSTEM),
+    ('rocm', '5.6.1', '', SYSTEM),
+    ('gcc-mixed/12.2.0', EXTERNAL_MODULE),
+    ('cray-libsci/23.09.1.1',   EXTERNAL_MODULE),
 ]
 
-#dependencies = [
-#    ('rocm',   EXTERNAL_MODULE),
-#]
+builddependencies = [
+    ('buildtools',   '%(toolchain_version)s',   '', True),
+]
 
-preconfigopts = 'unset MPICXX && unset MPICC && '
+preconfigopts  = 'unset MPICXX && unset MPICC && '
+preconfigopts += 'export C_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+preconfigopts += 'export CPLUS_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+preconfigopts += 'export LIBRARY_PATH=${EBROOTBOOST}/lib:${EBROOTBUILDTOOLS}/lib:${ROCM_PATH}/lib && '
 
 configopts =  '-D CMAKE_BUILD_TYPE=Release '
-configopts += '-D CMAKE_C_COMPILER=cc '
-configopts += '-D CMAKE_CXX_COMPILER=CC '
-configopts += '-D CMAKE_HIP_COMPILER=$ROCM_PATH/llvm/bin/amdclang++ '
+configopts += '-D CMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/clang '
+configopts += '-D CMAKE_C_FLAGS="--gcc-toolchain=$GCC_PATH/snos/" '
+configopts += '-D CMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/clang++ '
+configopts += '-D CMAKE_CXX_FLAGS="--gcc-toolchain=$GCC_PATH/snos/" '
+configopts += '-D ROCM_PATH=${ROCM_PATH} '
+configopts += '-D ROCM_CXX_FLAGS="--gcc-toolchain=$GCC_PATH/snos/" '
+configopts += '-D CMAKE_HIP_COMPILER=${ROCM_PATH}/llvm/bin/clang++ '
 configopts += '-D QUDA_TARGET_TYPE=HIP '
 configopts += '-D QUDA_BUILD_ALL_TESTS=ON '
 configopts += '-D QUDA_MPI=ON '

--- a/easybuild/easyconfigs/q/QUDA/QUDA-25102022-cpeAMD-22.08-GPU.eb
+++ b/easybuild/easyconfigs/q/QUDA/QUDA-25102022-cpeAMD-22.08-GPU.eb
@@ -1,0 +1,66 @@
+easyblock = 'CMakeMake'
+
+name = 'QUDA'
+version = '25102022'
+versionsuffix = "-GPU"
+
+homepage = 'https://lattice.github.io/quda/'
+
+description = """QUDA is a library for performing calculations in lattice QCD on GPUs."""
+
+
+toolchain = {'name': 'cpeAMD', 'version': '22.08'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'strict': True}
+
+sources = [{
+    'filename':   'quda-%(version)s.tar.gz',    
+    'git_config': {
+        'url': 'https://github.com/lattice',
+        'repo_name': 'quda',
+        'commit': '0a31b22738ca0a2a42176bf6b4460119d74112fc'
+    }
+}]
+
+builddependencies = [
+    ('buildtools',   '%(toolchain_version)s',   '', True),
+    ('rocm',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('rocm',   EXTERNAL_MODULE),
+    ('cray-libsci',   EXTERNAL_MODULE),
+]
+
+configopts =  '-D CMAKE_BUILD_TYPE=Release '
+configopts += '-D QUDA_TARGET_TYPE=HIP '
+configopts += '-D QUDA_BUILD_ALL_TESTS=ON '
+configopts += '-D QUDA_MPI=ON '
+configopts += '-D QUDA_DIRAC_CLOVER=ON '
+configopts += '-D QUDA_DIRAC_CLOVER_HASENBUSCH=ON '
+configopts += '-D QUDA_DIRAC_DOMAIN_WALL=OFF '
+configopts += '-D QUDA_DIRAC_NDEG_TWISTED_MASS=ON '
+configopts += '-D QUDA_DIRAC_NDEG_TWISTED_CLOVER=ON '
+configopts += '-D QUDA_DIRAC_STAGGERED=ON '
+configopts += '-D QUDA_DIRAC_TWISTED_MASS=ON '
+configopts += '-D QUDA_DIRAC_TWISTED_CLOVER=ON '
+configopts += '-D QUDA_DIRAC_WILSON=ON '
+configopts += '-D QUDA_FORCE_GAUGE=ON '
+configopts += '-D QUDA_FORCE_HISQ=OFF '
+configopts += '-D QUDA_GAUGE_ALG=ON '
+configopts += '-D QUDA_GAUGE_TOOLS=OFF '
+configopts += '-D QUDA_MULTIGRID=ON '
+configopts += '-D QUDA_INTERFACE_MILC=OFF '
+configopts += '-D QUDA_INTERFACE_CPS=OFF '
+configopts += '-D QUDA_INTERFACE_QDP=ON '
+configopts += '-D QUDA_INTERFACE_TIFR=OFF '
+configopts += '-D QUDA_DOWNLOAD_USQCD=ON '
+configopts += '-D QUDA_GPU_ARCH=gfx90a '
+configopts += '-D AMDGPU_TARGETS=gfx90a '
+configopts += '-D GPU_TARGETS=gfx90a '
+
+sanity_check_paths = {
+    'files': ['lib/libquda.so'],
+    'dirs':  ['bin', 'lib', 'include'],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/q/QUDA/QUDA-25102022-cpeAMD-22.08-GPU.eb
+++ b/easybuild/easyconfigs/q/QUDA/QUDA-25102022-cpeAMD-22.08-GPU.eb
@@ -22,16 +22,21 @@ sources = [{
 }]
 
 builddependencies = [
+    ('rocm',   EXTERNAL_MODULE),
     ('buildtools',   '%(toolchain_version)s',   '', True),
-    ('rocm',   EXTERNAL_MODULE),
-]
-
-dependencies = [
-    ('rocm',   EXTERNAL_MODULE),
     ('cray-libsci',   EXTERNAL_MODULE),
 ]
 
+#dependencies = [
+#    ('rocm',   EXTERNAL_MODULE),
+#]
+
+preconfigopts = 'unset MPICXX && unset MPICC && '
+
 configopts =  '-D CMAKE_BUILD_TYPE=Release '
+configopts += '-D CMAKE_C_COMPILER=cc '
+configopts += '-D CMAKE_CXX_COMPILER=CC '
+configopts += '-D CMAKE_HIP_COMPILER=$ROCM_PATH/llvm/bin/amdclang++ '
 configopts += '-D QUDA_TARGET_TYPE=HIP '
 configopts += '-D QUDA_BUILD_ALL_TESTS=ON '
 configopts += '-D QUDA_MPI=ON '


### PR DESCRIPTION
It was tested with tmLQCD project with rocm 5.2.3 and 5.3.3 but not earlier versions.