### PR TITLE
Fixes for VASP IO problems during startup

### DIFF
--- a/easybuild/easyconfigs/v/VASP/POTCAR-readonly.patch
+++ b/easybuild/easyconfigs/v/VASP/POTCAR-readonly.patch
@@ -1,0 +1,43 @@
+From c601b4a04eb911c6191b59da6d630c7e65bf6225 Mon Sep 17 00:00:00 2001
+From: Peter Larsson <egplar@gmail.com>
+Date: Wed, 8 Feb 2023 23:16:42 +0200
+Subject: [PATCH] Open POTCAR files readonly
+
+This seems to help with the slow reads at program startup on LUMI, especially with HDF5 enabled.
+---
+ src/pseudo.F | 4 ++--
+ src/string.F | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/pseudo.F b/src/pseudo.F
+index b29d944..5e09051 100644
+--- a/src/pseudo.F
++++ b/src/pseudo.F
+@@ -212,9 +212,9 @@ MODULE PSEUDO
+ !        END IF
+       END IF
+ #endif
+-      OPEN(UNIT=10,FILE=DIR_APP(1:DIR_LEN)//'POTCAR',STATUS='OLD',IOSTAT=IERR)
++      OPEN(UNIT=10,FILE=DIR_APP(1:DIR_LEN)//'POTCAR',ACTION='READ',STATUS='OLD',IOSTAT=IERR)
+       IF (IERR/=0) THEN
+-         OPEN(UNIT=10,FILE='POTCAR',STATUS='OLD')
++         OPEN(UNIT=10,FILE='POTCAR',ACTION='READ',STATUS='OLD')
+       ENDIF
+ 
+       LPAW = .FALSE.
+diff --git a/src/string.F b/src/string.F
+index 5aa9267..530f363 100644
+--- a/src/string.F
++++ b/src/string.F
+@@ -93,7 +93,7 @@ contains
+         integer, intent(out) :: ierr
+         character(len=:), allocatable :: content
+         integer file_unit
+-        open(newunit=file_unit,file=filename,status='old',form='unformatted',access='stream',iostat=ierr)
++        open(newunit=file_unit,file=filename,status='old',action='read',form='unformatted',access='stream',iostat=ierr)
+         if (ierr /= 0) then
+             content = ""
+             return
+-- 
+2.34.1
+

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4.pl2.build02-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4.pl2.build02-cpeGNU-22.08.eb
@@ -1,0 +1,40 @@
+# Based on CSCS VASP easyconfig by Luca Marsella
+# Adapted for LUMI by Peter Larsson
+
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4.pl2.build02'
+
+homepage = 'http://www.vasp.at'
+description = 'The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles.'
+
+toolchain = { 'name': 'cpeGNU', 'version': '22.08' }
+toolchainopts = {'usempi': True, 'openmp' : True }
+
+sources = ['vasp.5.4.4.pl2.tgz']
+
+dependencies = [
+	('Wannier90','3.1.0'),
+  ('cray-fftw', EXTERNAL_MODULE)
+]
+
+# Just copy in fully patched makefile.include
+patches = [('makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s','%(builddir)s/vasp.5.4.4.pl2'),('build02.patch')]
+
+# No checksum for makefile.include to simplify editing and recompiling
+checksums = [
+	'98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e',  # vasp.5.4.4.pl2.tgz
+]
+
+prebuildopts = 'mv makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s makefile.include && unset LIBS && '
+buildopts = "std"
+
+# Parallel building is still not working
+parallel = 1
+
+files_to_copy = [(['bin/vasp_std'],'bin')]
+
+sanity_check_paths = { 'files': ['bin/vasp_std'], 'dirs': [] }
+moduleclass = 'phys'
+

--- a/easybuild/easyconfigs/v/VASP/VASP-6.3.2.build02-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.3.2.build02-cpeGNU-22.08.eb
@@ -1,0 +1,43 @@
+# Based on CSCS VASP easyconfig by Luca Marsella
+# Adapted for LUMI by Peter Larsson
+
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.3.2.build02'
+
+homepage = 'http://www.vasp.at'
+description = 'The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles.'
+
+toolchain = { 'name': 'cpeGNU', 'version': '22.08' }
+toolchainopts = {'usempi': True, 'openmp' : True }
+
+sources = ['vasp.6.3.2.tgz']
+
+dependencies = [
+	('Wannier90','3.1.0'),
+	('DFTD4','3.4.0'),
+    ('libxc','5.2.2'),
+  ('cray-fftw', EXTERNAL_MODULE),
+  ('cray-hdf5', EXTERNAL_MODULE),
+]
+
+# Just copy in fully patched makefile.include
+patches = [('makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s','%(builddir)s/vasp.6.3.2'),('POTCAR-readonly.patch')]
+
+# No checksum for makefile.include to simplify editing and recompiling
+checksums = [
+	'f7595221b0f9236a324ea8afe170637a578cdd5a837cc7679e7f7812f6edf25a',  # vasp.6.3.2.tgz
+]
+
+prebuildopts = 'mv makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s makefile.include && unset LIBS && '
+buildopts = "std gam ncl"
+
+# Parallel building is still not working
+parallel = 1
+
+files_to_copy = [(['bin/vasp_std','bin/vasp_gam','bin/vasp_ncl'],'bin')]
+
+sanity_check_paths = { 'files': ['bin/vasp_std'], 'dirs': [] }
+moduleclass = 'phys'
+

--- a/easybuild/easyconfigs/v/VASP/build02.patch
+++ b/easybuild/easyconfigs/v/VASP/build02.patch
@@ -1,0 +1,11 @@
+--- src/lib/drdatab.F	2019-11-04 15:45:34.000000000 +0200
++++ ../vasp.5.4.4.pl2/src/lib/drdatab.F	2023-01-29 11:19:24.000000000 +0200
+@@ -125,7 +125,7 @@
+          WORK=FNAM
+          CALL STRIP(WORK,L,'A')
+          IF (L.EQ.0) GOTO 10
+-         OPEN(IU,FILE=WORK(1:L),STATUS='OLD',ERR=10)
++         OPEN(IU,FILE=WORK(1:L),STATUS='OLD',ACTION='READ',ERR=10)
+       ELSE
+          REWIND IU
+       ENDIF

--- a/easybuild/easyconfigs/v/VASP/makefile.include.VASP-5.4.4.pl2.build02-cpeGNU-22.08
+++ b/easybuild/easyconfigs/v/VASP/makefile.include.VASP-5.4.4.pl2.build02-cpeGNU-22.08
@@ -1,0 +1,80 @@
+# Precompiler options
+CPP_OPTIONS= -DHOST=\"LUMI2208B02\" \
+             -DMPI -DMPI_BLOCK=65536 \
+             -Duse_collective \
+             -DscaLAPACK \
+             -DCACHE_SIZE=4000 \
+             -Davoidalloc \
+             -Duse_bse_te \
+             -Dtbdyn \
+             -Duse_shmem -DnoSTOPCAR -DVASP2WANNIER90v2 -Duse_shmem
+
+CPP        = gcc -E -P -C -w $*$(FUFFIX) >$*$(SUFFIX) $(CPP_OPTIONS)
+
+FC         = ftn
+FCL        = ftn
+
+FREE       = -ffree-form -ffree-line-length-none
+
+FFLAGS     = -w -march=znver2 -ffpe-summary=none -fallow-argument-mismatch
+OFLAG      = -O2
+OFLAG_IN   = $(OFLAG)
+DEBUG      = -O0
+
+LIBDIR     = 
+BLAS       = 
+LAPACK     = 
+BLACS      = 
+SCALAPACK  = 
+WANNIER90  = -L$(EBROOTWANNIER90)/lib -lwannier 
+LLIBS      = $(SCALAPACK) $(LAPACK) $(BLAS) $(WANNIER90) 
+
+FFTW       ?= 
+LLIBS      += 
+INCS       = -I$(FFTW_INC)
+
+OBJECTS    = fftmpiw.o fftmpi_map.o  fftw3d.o  fft3dlib.o
+
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB    = $(CPP)
+FC_LIB     = $(FC)
+CC_LIB     = gcc
+CFLAGS_LIB = -O
+FFLAGS_LIB = -O1
+FREE_LIB   = $(FREE)
+
+OBJECTS_LIB= linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS   = g++
+
+LIBS       += parser
+LLIBS      += -Lparser -lparser -lstdc++
+
+# Normally no need to change this
+SRCDIR     = ../../src
+BINDIR     = ../../bin
+
+#================================================
+# GPU Stuff
+
+CPP_GPU    = -DCUDA_GPU -DRPROMU_CPROJ_OVERLAP -DCUFFT_MIN=28 -UscaLAPACK # -DUSE_PINNED_MEMORY 
+
+OBJECTS_GPU= fftmpiw.o fftmpi_map.o fft3dlib.o fftw3d_gpu.o fftmpiw_gpu.o
+
+CC         = gcc
+CXX        = g++
+CFLAGS     = -fPIC -DADD_ -openmp -DMAGMA_WITH_MKL -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
+
+CUDA_ROOT  ?= /usr/local/cuda
+NVCC       := $(CUDA_ROOT)/bin/nvcc
+CUDA_LIB   := -L$(CUDA_ROOT)/lib64 -lnvToolsExt -lcudart -lcuda -lcufft -lcublas
+
+GENCODE_ARCH    := -gencode=arch=compute_30,code=\"sm_30,compute_30\" \
+                   -gencode=arch=compute_35,code=\"sm_35,compute_35\" \
+                   -gencode=arch=compute_60,code=\"sm_60,compute_60\"
+
+MPI_INC    = /opt/gfortran/openmpi-1.10.2/install/ompi-1.10.2-GFORTRAN-5.4.1/include

--- a/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.3.2.build02-cpeGNU-22.08
+++ b/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.3.2.build02-cpeGNU-22.08
@@ -1,0 +1,98 @@
+# Default precompiler options
+CPP_OPTIONS = -DHOST=\"LUMI2208B02\" \
+              -DMPI -DMPI_BLOCK=65536 -Duse_collective \
+              -DscaLAPACK \
+              -DCACHE_SIZE=4000 \
+              -Davoidalloc \
+              -Dvasp6 \
+              -Duse_bse_te \
+              -Dtbdyn \
+              -Dfock_dblbuf \
+              -D_OPENMP -Duse_shmem -DnoSTOPCAR -DDFTD4 -DUSELIBXC
+
+CPP         = gcc -E -C -w $*$(FUFFIX) >$*$(SUFFIX) $(CPP_OPTIONS)
+
+FC          = ftn -fopenmp
+FCL         = ftn -fopenmp
+
+FREE        = -ffree-form -ffree-line-length-none
+
+FFLAGS      = -w -ffpe-summary=none
+
+OFLAG       = -O2
+OFLAG_IN    = $(OFLAG)
+DEBUG       = -O0
+
+OBJECTS     = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+OBJECTS_O3 += vdw_nl.o
+
+# For what used to be vasp.5.lib
+CPP_LIB     = $(CPP)
+FC_LIB      = $(FC)
+CC_LIB      = gcc
+CFLAGS_LIB  = -O
+FFLAGS_LIB  = -O1
+FREE_LIB    = $(FREE)
+
+OBJECTS_LIB = linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS    = g++
+LLIBS       = -lstdc++
+
+##
+## Customize as of this point! Of course you may change the preceding
+## part of this file as well if you like, but it should rarely be
+## necessary ...
+##
+
+# When compiling on the target machine itself, change this to the
+# relevant target when cross-compiling for another architecture
+# march is set by the craype-x86-milan module when compiling for LUMI-C partition
+#FFLAGS     += -march=znver3
+
+# For gcc-10 and higher (comment out for older versions)
+FFLAGS     += -fallow-argument-mismatch
+
+# BLAS and LAPACK (mandatory)
+#OPENBLAS_ROOT ?= /path/to/your/openblas/installation
+BLASPACK    = 
+
+# scaLAPACK (mandatory)
+#SCALAPACK_ROOT ?= /path/to/your/scalapack/installation
+SCALAPACK   = 
+
+LLIBS      += $(SCALAPACK) $(BLASPACK)
+
+# FFTW (mandatory)
+#FFTW_ROOT  ?= /path/to/your/fftw/installation
+# Note the explicit linking to -lffttw3_omp. It needs to be done due a bug in the build system.
+# For some reason, the Cray ftn wrapper does not pick up that OpenMP is enabled for FFTW
+LLIBS      += -L$(FFTW_ROOT)/lib -lfftw3 -lfftw3_omp
+INCS       += -I$(FFTW_INC) $(shell pkg-config --cflags dftd4) 
+
+# HDF5-support (optional but strongly recommended)
+# Use HDF5 from the Cray-module
+CPP_OPTIONS+= -DVASP_HDF5
+#HDF5_ROOT  ?= /path/to/your/hdf5/installation
+LLIBS      += -L$(HDF5_ROOT)/lib -lhdf5_fortran
+INCS       += -I$(HDF5_ROOT)/include
+
+# For the VASP-2-Wannier90 interface (optional)
+CPP_OPTIONS    += -DVASP2WANNIER90
+#WANNIER90_ROOT ?=  
+LLIBS          += -L$(EBROOTWANNIER90)/lib -lwannier -L/$(shell pkg-config --libs dftd4) 
+
+# Add Libxc
+LLIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
+INCS      += -I$(EBROOTLIBXC)/include
+
+# For the fftlib library (experimental)
+CPP_OPTIONS+= -Dsysv
+FCL        += fftlib.o
+CXX_FFTLIB  = g++ -fopenmp -std=c++11 -DFFTLIB_THREADSAFE
+INCS_FFTLIB = -I./include -I$(FFTW_ROOT)/include
+LIBS       += fftlib
+LLIBS      += -ldl


### PR DESCRIPTION
VASP 5 and 6 (with HDF5 enabled) can hang for several minutes on startup on LUMI. The reason is that all ranks try to read the input files with write access at the same time. These EB recipes applies patches to the VASP sources which reads POTCAR and INCAR in read-only mode. It helps.