### PR TITLE
Fix for PETSC 22.08 CPU broken dependencies

### DIFF
--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.1-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-5.5.1-cpeGNU-22.08.eb
@@ -10,7 +10,8 @@ description = "A parallel sparse direct solver"
 # TODO: Add note on specific license
 
 toolchain = {'name': 'cpeGNU', 'version': '22.08'}
-toolchainopts = {'pic': True, 'usempi': True}
+# It is OpenMP enabled version, toolchain option is for clarity
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
 
 source_urls = ['https://mumps-solver.org/']
 sources = ['%(name)s_%(version)s.tar.gz']

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('cray-hdf5-parallel', EXTERNAL_MODULE),
     ('Boost', '1.79.0'),
     ('METIS', '5.1.0'),
+    ('ParMETIS','4.0.3'),
     ('SCOTCH', '6.1.3'),
     #('MUMPS', '5.4.0', '-metis'),
     #('SuiteSparse', '5.10.1', '-METIS-5.1.0'),
@@ -36,7 +37,7 @@ configopts += ' CC=cc CXX=CC FC=ftn --with-cc=cc --with-cxx=CC --with-fc=ftn '
 configopts += 'CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" FCFLAGS="$FCFLAGS" FFLAGS="$FFLAGS" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" '
 configopts += '--with-fortran-datatypes=1 --with-fortran-interfaces=1 --with-fortran-bindings=1 --with-cxx-dialect=C++11 '
 configopts += '--with-x=0 --with-ssl=0 --with-shared-libraries=1 --with-mpiexec=srun --with-blas-lapack=1 --with-metis=1 --with-hypre=0 --with-scalapack=1 --with-ptscotch=1 --with-mumps=0 --with-hdf5=1 '
-configopts += '--with-metis-dir="$EBROOTMETIS" --with-hdf5-dir="$CRAY_HDF5_PARALLEL_PREFIX" --with-ptscotch-dir="$EBROOTSCOTCH"'
+configopts += '--with-metis-dir="$EBROOTMETIS" --with-parmetis-dir="$EBROOTPARMETIS" --with-hdf5-dir="$CRAY_HDF5_PARALLEL_PREFIX" --with-ptscotch-dir="$EBROOTSCOTCH"'
 
 # This is for checking if linking against the library is correct
 runtest = 'check_build MPIEXEC=exec V=1'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
@@ -8,7 +8,7 @@ description = """PETSc, pronounced PET-see (the S is silent), is a suite of data
  scalable (parallel) solution of scientific applications modeled by partial differential equations."""
 
 toolchain = {'name': 'cpeGNU', 'version': '22.08'}
-#toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
 
 source_urls = [
     'https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/',
@@ -24,10 +24,10 @@ dependencies = [
     ('METIS', '5.1.0'),
     ('ParMETIS','4.0.3'),
     ('SCOTCH', '6.1.3'),
-    ('MUMPS', '5.5.1', '-metis'),
+    ('MUMPS', '5.5.1'),
     ('Hypre', '2.26.0'),
     ('SuperLU_DIST', '8.1.2'),
-    ('STRUMPACK', '6.3.1'),
+    ('STRUMPACK', '6.3.1', '-CPU'),
 ]
 
 local_petsc_arch = 'cray-x86-milan-gnu'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.17.4-cpeGNU-22.08.eb
@@ -24,9 +24,10 @@ dependencies = [
     ('METIS', '5.1.0'),
     ('ParMETIS','4.0.3'),
     ('SCOTCH', '6.1.3'),
-    #('MUMPS', '5.4.0', '-metis'),
-    #('SuiteSparse', '5.10.1', '-METIS-5.1.0'),
-    #('Hypre', '2.21.0'),
+    ('MUMPS', '5.5.1', '-metis'),
+    ('Hypre', '2.26.0'),
+    ('SuperLU_DIST', '8.1.2'),
+    ('STRUMPACK', '6.3.1'),
 ]
 
 local_petsc_arch = 'cray-x86-milan-gnu'
@@ -36,8 +37,8 @@ configopts = '--with-petsc-arch=' + local_petsc_arch
 configopts += ' CC=cc CXX=CC FC=ftn --with-cc=cc --with-cxx=CC --with-fc=ftn '
 configopts += 'CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" FCFLAGS="$FCFLAGS" FFLAGS="$FFLAGS" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" '
 configopts += '--with-fortran-datatypes=1 --with-fortran-interfaces=1 --with-fortran-bindings=1 --with-cxx-dialect=C++11 '
-configopts += '--with-x=0 --with-ssl=0 --with-shared-libraries=1 --with-mpiexec=srun --with-blas-lapack=1 --with-metis=1 --with-hypre=0 --with-scalapack=1 --with-ptscotch=1 --with-mumps=0 --with-hdf5=1 '
-configopts += '--with-metis-dir="$EBROOTMETIS" --with-parmetis-dir="$EBROOTPARMETIS" --with-hdf5-dir="$CRAY_HDF5_PARALLEL_PREFIX" --with-ptscotch-dir="$EBROOTSCOTCH"'
+configopts += '--with-x=0 --with-ssl=0 --with-shared-libraries=1 --with-mpiexec=srun --with-blas-lapack=1 --with-metis=1 --with-hypre=1 --with-scalapack=1 --with-ptscotch=1 --with-mumps=1 --with-hdf5=1 --with-superlu_dist=1 --with-strumpack=1 '
+configopts += '--with-metis-dir="$EBROOTMETIS" --with-parmetis-dir="$EBROOTPARMETIS" --with-hdf5-dir="$CRAY_HDF5_PARALLEL_PREFIX" --with-ptscotch-dir="$EBROOTSCOTCH" --with-hypre-dir="$EBROOTHYPRE" --with-mumps-dir="$EBROOTMUMPS" --with-superlu_dist-dir="$EBROOTSUPERLU_DIST" --with-strumpack-dir="$EBROOTSTRUMPACK" '
 
 # This is for checking if linking against the library is correct
 runtest = 'check_build MPIEXEC=exec V=1'


### PR DESCRIPTION
It is to fix problems with incorrect dependency name suffixes.