### PR TITLE
Remove ROCM version in the OpenMPI-4.1.3 recipe

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.3-cpeGNU-22.08.eb
@@ -28,7 +28,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9c0fd1f78fc90ca9b69ae4ab704687d5544220005ccd7678bf58cc13135e67e0']
 
 dependencies = [
-    ('rocm/5.0.2', EXTERNAL_MODULE)
+    ('rocm', EXTERNAL_MODULE)
 ]
 
 configopts  = '--with-libfabric=/opt/cray/libfabric/$(pkg-config --modversion libfabric) '


### PR DESCRIPTION
Closes #93 