### PR TITLE
Add hipfort for cpeCray

### DIFF
--- a/easybuild/easyconfigs/h/hipfort/LICENSE.md
+++ b/easybuild/easyconfigs/h/hipfort/LICENSE.md
@@ -1,0 +1,2 @@
+hipfort is released under the MITx11 License. A copy of the license can be found
+in the [hipfort Github repository](https://github.com/ROCmSoftwarePlatform/hipfort/blob/develop/LICENSE).

--- a/easybuild/easyconfigs/h/hipfort/README.md
+++ b/easybuild/easyconfigs/h/hipfort/README.md
@@ -1,0 +1,14 @@
+# hifort
+
+-   [hipfort web site](https://rocmdocs.amd.com/projects/hipfort/en/latest/)
+-   [hipfort on GitHub](https://github.com/ROCmSoftwarePlatform/hipfort)
+
+
+## EasyBuild
+
+-   No support in the EasyBuilders repository at the time of writing.
+-   No support in the CSCS repository at the time of writing.
+
+### Version 0.4.0 for cpeCray 
+
+- Custom easyconfig created for LUMI

--- a/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.08-rocm5.2.eb
+++ b/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.08-rocm5.2.eb
@@ -1,0 +1,100 @@
+# Created for LUMI by Orian Louant
+
+easyblock = 'CMakeMake'
+
+name = 'hipfort'
+version = '0.4-0'
+versionsuffix = '-rocm5.2'
+
+local_rocm_version = '5.2.3'
+
+homepage = 'https://rocmdocs.amd.com/projects/hipfort/en/latest/'
+
+whatis = ['Description: FORTRAN interface library for accessing AMD GPU Kernels.']
+
+description = """
+ hipfort is a FORTRAN interface library for accessing AMD GPU Kernels. It
+ provides interfaces to the following HIP and ROCm libraries:
+ 
+  - HIP: HIP runtime, hipBLAS, hipSPARSE, hipFFT, hipRAND, hipSOLVER
+  - ROCm: rocBLAS, rocSPARSE, rocFFT, rocRAND, rocSOLVER
+
+ The role of this package is to replace the default hipfort installation that 
+ only support gfortran. This package provide Fortran modules compatible 
+ with the Cray Fortran compiler as well as direct use of hipfort with the 
+ Fortran Cray Compiler wrapper (ftn). 
+ 
+ The main use case is for Fortran code using a mix of OpenACC and HIP kernels as
+ only the Cray compiler supports OpenACC on LUMI.
+"""
+
+usage = """
+ This module can be used in two ways. The first option is to use the AMD 
+ provided 'hipfc' compiler script:
+
+  $ hipfc -o out.exe --offload-arch=gfx90a hip_kernels.cpp fortran_code.f90
+
+ With this method, the fortran code and 
+ The second option is use the Cray 'ftn' compiler wrapper as you would do to
+ compile any fortran code. The appropriate module and library search paths as
+ well as library linking flags will be automatically added by the compiler 
+ wrappper:
+
+  $ ftn -c fortran_code.f90
+  $ CC -xhip -c hip_kernels.cpp
+  $ ftn -o out.exe fortran_code.o hip_kernels.o
+"""
+
+docurls = ['https://rocmdocs.amd.com/projects/hipfort/en/latest/']
+software_license_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/blob/develop/LICENSE']
+
+local_pkgconfig_content = """
+includedir=%(installdir)s/include
+libdir=%(installdir)s/lib
+
+Name: hipfort
+Description: Fortran interface for AMD GPU kernels
+Version: 0.4-0
+
+Libs: -L${libdir} -lhipfort-amdgcn
+Cflags: -eT -J${includedir}/hipfort/amdgcn/
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+
+source_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/archive/refs/tags/']
+sources = ['rocm-%s.tar.gz' % local_rocm_version]
+checksums = ['6648350ca4edc8757f0ae51d73a05a9a536808f19ad45f5b5ab84d420c72c9ec']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('rocm/%s' % local_rocm_version, EXTERNAL_MODULE),
+]
+
+configopts  = ' -DHIPFORT_COMPILER=ftn'
+configopts += ' -DHIPFORT_COMPILER_FLAGS="-ffree -eZ"'
+configopts += ' -DHIPFORT_INSTALL_DIR=%(installdir)s'
+configopts += ' -DHIPFORT_AR=${CRAY_BINUTILS_BIN_X86_64}/ar'
+configopts += ' -DHIPFORT_RANLIB=${CRAY_BINUTILS_BIN_X86_64}/ranlib'
+
+local_pkgconfig_dir = '%(installdir)s/lib/pkgconfig'
+local_pkgconfig_file = local_pkgconfig_dir + '/hipfort.pc'
+
+postinstallcmds = [
+    'mkdir -p ' + local_pkgconfig_dir,
+    'cat <<EOF > ' + local_pkgconfig_file + '\n' + local_pkgconfig_content.replace('$', '\$') + '\nEOF\n',
+]
+
+modluafooter = """
+prepend_path("PE_FORTRAN_PKGCONFIG_LIBS", "hipfort")
+"""
+
+sanity_check_paths = {
+    'files': ['bin/hipfc', 'lib/libhipfort-amdgcn.a'],
+    'dirs': ['include/hipfort/amdgcn'],
+}
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.08-rocm5.3.eb
+++ b/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.08-rocm5.3.eb
@@ -1,0 +1,100 @@
+# Created for LUMI by Orian Louant
+
+easyblock = 'CMakeMake'
+
+name = 'hipfort'
+version = '0.4-0'
+versionsuffix = '-rocm5.3'
+
+local_rocm_version = '5.3.3'
+
+homepage = 'https://rocmdocs.amd.com/projects/hipfort/en/latest/'
+
+whatis = ['Description: FORTRAN interface library for accessing AMD GPU Kernels.']
+
+description = """
+ hipfort is a FORTRAN interface library for accessing AMD GPU Kernels. It
+ provides interfaces to the following HIP and ROCm libraries:
+ 
+  - HIP: HIP runtime, hipBLAS, hipSPARSE, hipFFT, hipRAND, hipSOLVER
+  - ROCm: rocBLAS, rocSPARSE, rocFFT, rocRAND, rocSOLVER
+
+ The role of this package is to replace the default hipfort installation that 
+ only support gfortran. This package provide Fortran modules compatible 
+ with the Cray Fortran compiler as well as direct use of hipfort with the 
+ Fortran Cray Compiler wrapper (ftn). 
+ 
+ The main use case is for Fortran code using a mix of OpenACC and HIP kernels as
+ only the Cray compiler supports OpenACC on LUMI.
+"""
+
+usage = """
+ This module can be used in two ways. The first option is to use the AMD 
+ provided 'hipfc' compiler script:
+
+  $ hipfc -o out.exe --offload-arch=gfx90a hip_kernels.cpp fortran_code.f90
+
+ With this method, the fortran code and 
+ The second option is use the Cray 'ftn' compiler wrapper as you would do to
+ compile any fortran code. The appropriate module and library search paths as
+ well as library linking flags will be automatically added by the compiler 
+ wrappper:
+
+  $ ftn -c fortran_code.f90
+  $ CC -xhip -c hip_kernels.cpp
+  $ ftn -o out.exe fortran_code.o hip_kernels.o
+"""
+
+docurls = ['https://rocmdocs.amd.com/projects/hipfort/en/latest/']
+software_license_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/blob/develop/LICENSE']
+
+local_pkgconfig_content = """
+includedir=%(installdir)s/include
+libdir=%(installdir)s/lib
+
+Name: hipfort
+Description: Fortran interface for AMD GPU kernels
+Version: 0.4-0
+
+Libs: -L${libdir} -lhipfort-amdgcn
+Cflags: -eT -J${includedir}/hipfort/amdgcn/
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.08'}
+
+source_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/archive/refs/tags/']
+sources = ['rocm-%s.tar.gz' % local_rocm_version]
+checksums = ['593be86502578b68215ffe767c26849fd27d4dbd92c8e76762275805f99e64f5']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('rocm/%s' % local_rocm_version, EXTERNAL_MODULE),
+]
+
+configopts  = ' -DHIPFORT_COMPILER=ftn'
+configopts += ' -DHIPFORT_COMPILER_FLAGS="-ffree -eZ"'
+configopts += ' -DHIPFORT_INSTALL_DIR=%(installdir)s'
+configopts += ' -DHIPFORT_AR=${CRAY_BINUTILS_BIN_X86_64}/ar'
+configopts += ' -DHIPFORT_RANLIB=${CRAY_BINUTILS_BIN_X86_64}/ranlib'
+
+local_pkgconfig_dir = '%(installdir)s/lib/pkgconfig'
+local_pkgconfig_file = local_pkgconfig_dir + '/hipfort.pc'
+
+postinstallcmds = [
+    'mkdir -p ' + local_pkgconfig_dir,
+    'cat <<EOF > ' + local_pkgconfig_file + '\n' + local_pkgconfig_content.replace('$', '\$') + '\nEOF\n',
+]
+
+modluafooter = """
+prepend_path("PE_FORTRAN_PKGCONFIG_LIBS", "hipfort")
+"""
+
+sanity_check_paths = {
+    'files': ['bin/hipfc', 'lib/libhipfort-amdgcn.a'],
+    'dirs': ['include/hipfort/amdgcn'],
+}
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.12-rocm5.2.eb
+++ b/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-22.12-rocm5.2.eb
@@ -1,0 +1,100 @@
+# Created for LUMI by Orian Louant
+
+easyblock = 'CMakeMake'
+
+name = 'hipfort'
+version = '0.4-0'
+versionsuffix = '-rocm5.2'
+
+local_rocm_version = '5.2.3'
+
+homepage = 'https://rocmdocs.amd.com/projects/hipfort/en/latest/'
+
+whatis = ['Description: FORTRAN interface library for accessing AMD GPU Kernels.']
+
+description = """
+ hipfort is a FORTRAN interface library for accessing AMD GPU Kernels. It
+ provides interfaces to the following HIP and ROCm libraries:
+
+  - HIP: HIP runtime, hipBLAS, hipSPARSE, hipFFT, hipRAND, hipSOLVER
+  - ROCm: rocBLAS, rocSPARSE, rocFFT, rocRAND, rocSOLVER
+
+ The role of this package is to replace the default hipfort installation that
+ only support gfortran. This package provide Fortran modules compatible
+ with the Cray Fortran compiler as well as direct use of hipfort with the
+ Fortran Cray Compiler wrapper (ftn).
+
+ The main use case is for Fortran code using a mix of OpenACC and HIP kernels as
+ only the Cray compiler supports OpenACC on LUMI.
+"""
+
+usage = """
+ This module can be used in two ways. The first option is to use the AMD
+ provided 'hipfc' compiler script:
+
+  $ hipfc -o out.exe --offload-arch=gfx90a hip_kernels.cpp fortran_code.f90
+
+ With this method, the fortran code and
+ The second option is use the Cray 'ftn' compiler wrapper as you would do to
+ compile any fortran code. The appropriate module and library search paths as
+ well as library linking flags will be automatically added by the compiler
+ wrappper:
+
+  $ ftn -c fortran_code.f90
+  $ CC -xhip -c hip_kernels.cpp
+  $ ftn -o out.exe fortran_code.o hip_kernels.o
+"""
+
+docurls = ['https://rocmdocs.amd.com/projects/hipfort/en/latest/']
+software_license_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/blob/develop/LICENSE']
+
+local_pkgconfig_content = """
+includedir=%(installdir)s/include
+libdir=%(installdir)s/lib
+
+Name: hipfort
+Description: Fortran interface for AMD GPU kernels
+Version: 0.4-0
+
+Libs: -L${libdir} -lhipfort-amdgcn
+Cflags: -eT -J${includedir}/hipfort/amdgcn/
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '22.12'}
+
+source_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/archive/refs/tags/']
+sources = ['rocm-%s.tar.gz' % local_rocm_version]
+checksums = ['6648350ca4edc8757f0ae51d73a05a9a536808f19ad45f5b5ab84d420c72c9ec']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('rocm/%s' % local_rocm_version, EXTERNAL_MODULE),
+]
+
+configopts  = ' -DHIPFORT_COMPILER=ftn'
+configopts += ' -DHIPFORT_COMPILER_FLAGS="-ffree -eZ"'
+configopts += ' -DHIPFORT_INSTALL_DIR=%(installdir)s'
+configopts += ' -DHIPFORT_AR=${CRAY_BINUTILS_BIN_X86_64}/ar'
+configopts += ' -DHIPFORT_RANLIB=${CRAY_BINUTILS_BIN_X86_64}/ranlib'
+
+local_pkgconfig_dir = '%(installdir)s/lib/pkgconfig'
+local_pkgconfig_file = local_pkgconfig_dir + '/hipfort.pc'
+
+postinstallcmds = [
+    'mkdir -p ' + local_pkgconfig_dir,
+    'cat <<EOF > ' + local_pkgconfig_file + '\n' + local_pkgconfig_content.replace('$', '\$') + '\nEOF\n',
+]
+
+modluafooter = """
+prepend_path("PE_FORTRAN_PKGCONFIG_LIBS", "hipfort")
+"""
+
+sanity_check_paths = {
+    'files': ['bin/hipfc', 'lib/libhipfort-amdgcn.a'],
+    'dirs': ['include/hipfort/amdgcn'],
+}
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-23.03-rocm5.2.eb
+++ b/easybuild/easyconfigs/h/hipfort/hipfort-0.4-0-cpeCray-23.03-rocm5.2.eb
@@ -1,0 +1,76 @@
+# Created for LUMI by Orian Louant
+
+easyblock = 'CMakeMake'
+
+name = 'hipfort'
+version = '0.4-0'
+versionsuffix = '-rocm5.2'
+
+local_rocm_version = '5.2.3'
+
+homepage = 'https://rocmdocs.amd.com/projects/hipfort/en/latest/'
+
+whatis = ['Description: FORTRAN interface library for accessing AMD GPU Kernels.']
+
+description = """
+ hipfort is a FORTRAN interface library for accessing AMD GPU Kernels. It
+ provides interfaces to the following HIP and ROCm libraries:
+
+  - HIP: HIP runtime, hipBLAS, hipSPARSE, hipFFT, hipRAND, hipSOLVER
+  - ROCm: rocBLAS, rocSPARSE, rocFFT, rocRAND, rocSOLVER
+
+ The role of this package is to replace the default hipfort installation that
+ only support gfortran. This package provide Fortran modules compatible
+ with the Cray Fortran compiler as well as direct use of hipfort with the
+ Fortran Cray Compiler wrapper (ftn).
+
+ The main use case is for Fortran code using a mix of OpenACC and HIP kernels as
+ only the Cray compiler supports OpenACC on LUMI.
+"""
+
+usage = """
+ This module can be used in two ways. The first option is to use the AMD
+ provided 'hipfc' compiler script:
+
+  $ hipfc -o out.exe --offload-arch=gfx90a hip_kernels.cpp fortran_code.f90
+
+ With this method, the fortran code and
+ The second option is use the Cray 'ftn' compiler wrapper as you would do to
+ compile any fortran code. The appropriate module and library search paths as
+ well as library linking flags will be automatically added by the compiler
+ wrappper:
+
+  $ ftn -c fortran_code.f90
+  $ CC -xhip -c hip_kernels.cpp
+  $ ftn -o out.exe fortran_code.o hip_kernels.o
+"""
+
+docurls = ['https://rocmdocs.amd.com/projects/hipfort/en/latest/']
+software_license_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/blob/develop/LICENSE']
+
+toolchain = {'name': 'cpeCray', 'version': '23.03'}
+
+source_urls = ['https://github.com/ROCmSoftwarePlatform/hipfort/archive/refs/tags/']
+sources = ['rocm-%s.tar.gz' % local_rocm_version]
+checksums = ['6648350ca4edc8757f0ae51d73a05a9a536808f19ad45f5b5ab84d420c72c9ec']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('rocm/%s' % local_rocm_version, EXTERNAL_MODULE),
+]
+
+configopts  = ' -DHIPFORT_COMPILER=ftn'
+configopts += ' -DHIPFORT_COMPILER_FLAGS="-ffree -eT"'
+configopts += ' -DHIPFORT_INSTALL_DIR=%(installdir)s'
+configopts += ' -DHIPFORT_AR=${CRAY_BINUTILS_BIN_X86_64}/ar'
+configopts += ' -DHIPFORT_RANLIB=${CRAY_BINUTILS_BIN_X86_64}/ranlib'
+
+sanity_check_paths = {
+    'files': ['bin/hipfc'],
+    'dirs': [],
+}
+
+moduleclass = 'compiler'


### PR DESCRIPTION
hipfort  easyconfigs with cpeCray for codes that include a mix of OpenACC and HIP runtime calls.