### PR TITLE
OpenFOAM for 22.12

### DIFF
--- a/easybuild/easyconfigs/c/CGAL/CGAL-4.12.2-cpeGNU-22.12-OpenFOAM.eb
+++ b/easybuild/easyconfigs/c/CGAL/CGAL-4.12.2-cpeGNU-22.12-OpenFOAM.eb
@@ -1,0 +1,37 @@
+#
+easyblock = 'CMakeMake'
+
+name =          'CGAL'
+version =       '4.12.2'
+versionsuffix = '-OpenFOAM'
+
+homepage = 'http://www.cgal.org/'
+whatis = [
+    "Description: CGAL provides easy access to efficient and reliable geometric algorithms in the form of a C++ library",
+    "This module is compiled to the specific needs of our OpenFOAM installations"
+]
+
+description = """
+The goal of the CGAL Open Source Project is to provide easy access to efficient
+and reliable geometric algorithms in the form of a C++ library.
+
+This module is compiled to the specific needs of our OpenFOAM installation.
+It does not include GUI support as we want to run OpenFOAM in batch mode.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'strict': True}
+
+#https://github.com/CGAL/cgal/releases/download/releases/CGAL-4.12.2/CGAL-4.12.2.tar.xz
+source_urls = ['https://github.com/%(name)s/%(namelower)s/releases/download/releases/CGAL-%(version)s']
+sources =     [SOURCE_TAR_XZ]
+checksums =   ['aa9b7d4c0e0a94a5147287edb1141822453dbeeb5b23a11983f05a3bd3a1b680']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('Boost',      '1.81.0',                ''),
+]
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DBoost_DIR=${EBROOTBOOST} -DWITH_ZLIB=ON -DCGAL_DISABLE_MPFR=TRUE -DCGAL_DISABLE_GMP=TRUE -DWITH_BLAS=ON -DWITH_CGAL_Qt5=OFF "
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-cpeGNU-22.12.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-cpeGNU-22.12.eb
@@ -1,0 +1,78 @@
+easyblock = 'Binary'
+
+name = 'OpenFOAM'
+version = 'v2106'
+
+whatis = [
+    'OpenFOAM is a free, open source CFD software package. OpenFOAM has an extensive range of features to solve anything from complex fluid flows involving chemical reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.'
+]
+
+homepage = 'http://www.openfoam.com/'
+
+whatis = [
+    'Description: The OpenFOAM (CFD software) distribution from OpenCFD Ltd'
+]
+
+description = """
+OpenFOAM is the free, open source CFD software developed primarily by OpenCFD Ltd since 2004.
+
+OpenCFD Ltd, owner of the OpenFOAM Trademark, is a wholly owned subsidiary of ESI Group.
+
+ESI-OpenCFD produces the OpenFOAM® open source CFD toolbox and distributes freely
+via https://www.openfoam.com/. OpenCFD Ltd was established in 2004 to coincide with
+the release of its OpenFOAM software under general public licence.
+
+OpenFOAM is distributed under the GPL v3 licence.
+"""
+
+usage = """
+Initialize the OpenFOAM environment with following command:
+
+ source $EBROOTOPENFOAM/etc/bashrc WM_COMPILER=Cray WM_MPLIB=CRAY-MPICH
+
+To run OpenFOAM solvers on compute nodes use srun command:
+
+ srun foamSolverName -parallel
+
+in either job script for sbatch or directly within salloc session.
+
+Allrun scripts require some additional tweaking.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'cstd': 'c++11'}
+
+source_urls = ['https://dl.%(namelower)s.com/source/%(version)s']
+sources = [SOURCE_TGZ]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('Boost',      '1.81.0', ''),
+]
+
+dependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('SCOTCH',    '7.0.3'),
+    ('CGAL',      '4.12.2',       '-OpenFOAM'),
+]
+
+unpack_options = '--strip-components=1'
+extract_sources = 'True'
+buildininstalldir = 'True'
+
+install_cmd  = "source etc/bashrc WM_COMPILER=Cray WM_MPLIB=CRAY-MPICH MPICH_DIR=${CRAY_MPICH_PREFIX} "
+install_cmd += "&& cp ./wmake/rules/General/cgal-no-mpfr ./wmake/rules/General/cgal "
+install_cmd += "&& export FOAM_EXTRA_CXXFLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' "  # This has to be set after sourcing etc/bashrc!
+install_cmd += "&& ./bin/tools/foamConfigurePaths -boost boost-system -boost-path ${EBROOTBOOST} -fftw fftw-system -fftw-path ${FFTW_ROOT} -scotch scotch-system -scotch-path ${EBROOTSCOTCH} -cgal cgal-system -cgal-path ${EBROOTCGAL} "
+install_cmd += "&& ./Allwmake -j 1"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs':  ['platforms/linux64CrayDPInt32Opt/bin', 'platforms/linux64CrayDPInt32Opt/lib'],
+}
+
+modextravars = {
+    'FOAM_BASH': '%(installdir)s/bashrc',
+}
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2212-cpeGNU-22.12.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2212-cpeGNU-22.12.eb
@@ -1,0 +1,78 @@
+easyblock = 'Binary'
+
+name = 'OpenFOAM'
+version = 'v2212'
+
+whatis = [
+    'OpenFOAM is a free, open source CFD software package. OpenFOAM has an extensive range of features to solve anything from complex fluid flows involving chemical reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.'
+]
+
+homepage = 'http://www.openfoam.com/'
+
+whatis = [
+    'Description: The OpenFOAM (CFD software) distribution from OpenCFD Ltd'
+]
+
+description = """
+OpenFOAM is the free, open source CFD software developed primarily by OpenCFD Ltd since 2004.
+
+OpenCFD Ltd, owner of the OpenFOAM Trademark, is a wholly owned subsidiary of ESI Group.
+
+ESI-OpenCFD produces the OpenFOAM® open source CFD toolbox and distributes freely
+via https://www.openfoam.com/. OpenCFD Ltd was established in 2004 to coincide with
+the release of its OpenFOAM software under general public licence.
+
+OpenFOAM is distributed under the GPL v3 licence.
+"""
+
+usage = """
+Initialize the OpenFOAM environment with following command:
+
+ source $EBROOTOPENFOAM/etc/bashrc WM_COMPILER=Cray WM_MPLIB=CRAY-MPICH
+
+To run OpenFOAM solvers on compute nodes use srun command:
+
+ srun foamSolverName -parallel
+
+in either job script for sbatch or directly within salloc session.
+
+Allrun scripts require some additional tweaking.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'cstd': 'c++11'}
+
+source_urls = ['https://dl.%(namelower)s.com/source/%(version)s']
+sources = [SOURCE_TGZ]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('Boost',      '1.81.0', ''),
+]
+
+dependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('SCOTCH',    '7.0.3'),
+    ('CGAL',      '4.12.2',       '-OpenFOAM'),
+]
+
+unpack_options = '--strip-components=1'
+extract_sources = 'True'
+buildininstalldir = 'True'
+
+install_cmd  = "source etc/bashrc WM_COMPILER=Cray WM_MPLIB=CRAY-MPICH MPICH_DIR=${CRAY_MPICH_PREFIX} "
+install_cmd += "&& cp ./wmake/rules/General/cgal-no-mpfr ./wmake/rules/General/cgal "
+install_cmd += "&& export FOAM_EXTRA_CXXFLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' "  # This has to be set after sourcing etc/bashrc!
+install_cmd += "&& ./bin/tools/foamConfigurePaths -boost boost-system -boost-path ${EBROOTBOOST} -fftw fftw-system -fftw-path ${FFTW_ROOT} -scotch scotch-system -scotch-path ${EBROOTSCOTCH} -cgal cgal-system -cgal-path ${EBROOTCGAL} "
+install_cmd += "&& ./Allwmake -j 1"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs':  ['platforms/linux64CrayDPInt32Opt/bin', 'platforms/linux64CrayDPInt32Opt/lib'],
+}
+
+modextravars = {
+    'FOAM_BASH': '%(installdir)s/bashrc',
+}
+
+moduleclass = 'cae'


### PR DESCRIPTION
Simple update of OpenFOAM v21.06 for toolchain 22.12 and upgrade to v22.12. Additional CGAL dependency with the toolchain version updated to 22.12. 