### PR TITLE
SuperLU and SuperLU_DIST easyconfigs for 22.12

### DIFF
--- a/easybuild/easyconfigs/s/SuperLU/SuperLU-6.0.0-cpeGNU-22.12-OpenMP.eb
+++ b/easybuild/easyconfigs/s/SuperLU/SuperLU-6.0.0-cpeGNU-22.12-OpenMP.eb
@@ -1,0 +1,40 @@
+easyblock = "CMakeMake"
+
+name = 'SuperLU'
+version = '6.0.0'
+versionsuffix = '-OpenMP'
+
+homepage = 'https://crd-legacy.lbl.gov/~xiaoye/SuperLU/'
+description = """SuperLU is a general purpose library for the 
+direct solution of large, sparse, nonsymmetric systems
+ of linear equations on high performance machines."""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+github_account = 'xiaoyeli'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ["v%(version)s.tar.gz"]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('ParMETIS', '4.0.3'),
+]
+
+configopts  = '-DTPL_ENABLE_METISLIB=ON '
+configopts += '-DTPL_METIS_INCLUDE_DIRS="${EBROOTPARMETIS}/include" '
+configopts += '-DTPL_METIS_LIBRARIES="${EBROOTPARMETIS}/lib/libparmetis.a;${EBROOTPARMETIS}/lib/libmetis.a" '
+configopts += '-DTPL_ENABLE_INTERNAL_BLASLIB=OFF '
+configopts += '-Denable_openmp:BOOL=TRUE '
+
+runtest = " test"
+
+sanity_check_paths = {
+    'files': ['lib64/libsuperlu.a'],
+    'dirs':  ['include']
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.1.2-cpeGNU-22.12-OpenMP.eb
+++ b/easybuild/easyconfigs/s/SuperLU_DIST/SuperLU_DIST-8.1.2-cpeGNU-22.12-OpenMP.eb
@@ -1,0 +1,66 @@
+easyblock = "CMakeMake"
+
+name =    'SuperLU_DIST'
+version = '8.1.2'
+versionsuffix = '-OpenMP'
+
+homepage = 'https://crd-legacy.lbl.gov/~xiaoye/SuperLU/'
+
+whatis = [
+    'Description: SuperLU is a general purpose library for the direct solution of large, sparse, ' +
+    'nonsymmetric systems of linear equations on high performance machines.'
+]
+
+description = """
+SuperLU is a general purpose library for the direct solution of large, sparse, 
+nonsymmetric systems of linear equations. The library is written in C and is 
+callable from either C or Fortran program. It uses MPI, OpenMP and CUDA to 
+support various forms of parallelism. It supports both real and complex 
+datatypes, both single and double precision, and 64-bit integer indexing. 
+The library routines performs an LU decomposition with partial pivoting and 
+triangular system solves through forward and back substitution. The LU 
+factorization routines can handle non-square matrices but the triangular 
+solves are performed only for square matrices. The matrix columns may be 
+preordered (before factorization) either through library or user supplied 
+routines. This preordering for sparsity is completely separate from the 
+factorization. Working precision iterative refinement subroutines are provided 
+for improved backward stability. Routines are also provided to equilibrate the 
+system, estimate the condition number, calculate the relative backward error, 
+and estimate error bounds for the refined solutions.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+github_account = 'xiaoyeli'
+source_urls =    [GITHUB_LOWER_SOURCE]
+sources =        ["v%(version)s.tar.gz"]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('ParMETIS', '4.0.3'),
+]
+
+configopts  = '-DTPL_PARMETIS_INCLUDE_DIRS="${EBROOTPARMETIS}/include" '
+configopts += '-DTPL_PARMETIS_LIBRARIES="${EBROOTPARMETIS}/lib/libparmetis.a;${EBROOTPARMETIS}/lib/libmetis.a" '
+configopts += '-DTPL_ENABLE_INTERNAL_BLASLIB=OFF '
+configopts += '-Denable_openmp:BOOL=TRUE '
+configopts += '-DMPIEXEC_EXECUTABLE="srun" '
+
+# Some tests run longer than default 1500s timeout on fairly big machine (36 cores).
+# Include only first four tests, which should be fairly small to run
+pretestopts = 'export ARGS="$ARGS --tests-regex pdtest_[21]x1_[13]_2_8_20_SP" && '
+
+sanity_check_paths = {
+    'files': ['lib64/libsuperlu_dist.a'],
+    'dirs':  ['include']
+}
+
+sanity_check_commands = [
+    'pkg-config --libs superlu_dist',
+]
+
+moduleclass = 'numlib'


### PR DESCRIPTION
Two independent easyconfigs for SuperLU and SuperLU_DIST, recent versions for 22.12, explicit (with a name suffix) OpenMP support.