### PR TITLE
ELPA 2023.05.001

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-cpeGNU-22.12-GPU.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.05.001-cpeGNU-22.12-GPU.eb
@@ -1,0 +1,78 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+easyblock = 'ConfigureMake'
+
+local_ELPA_version =           '2023.05.001'     # Synchronized with CSCS but also the version in EB 2021b
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-GPU'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'usempi': True, 'openmp': False}
+
+source_urls = ['https://gitlab.mpcdf.mpg.de/elpa/elpa/-/archive/new_release_%(version)s/']
+sources =     ['elpa-new_release_%(version)s.tar.gz']
+
+patches = [
+    {'name': 'elpa-2023.05.01.patch', 'level': 1},
+]
+
+builddependencies = [ # We use the system Python and Perl.
+    ('buildtools', '%(toolchain_version)s', '', True), # For Autotools and others.
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('rocm', EXTERNAL_MODULE)
+]
+
+preconfigopts  = './autogen.sh && '
+preconfigopts += " CC=cc CXX=hipcc FC=ftn && "
+
+local_commonopts  = ' FCFLAGS="$FCFLAGS" --enable-static --disable-openmp CXXFLAGS="--offload-arch=gfx90a --gcc-toolchain=$GCC_PATH/snos -std=c++17 -I$ROCM_PATH/include/hip -I$ROCM_PATH/include/rocblas -I$CRAY_MPICH_DIR/include" '
+local_commonopts += '--with-rocsolver --with-AMD-gpu-support-only --enable-gpu-ccl=rccl --enable-gpu-streams=amd --enable-amd-gpu-kernels '
+local_commonopts += '--disable-avx512-kernels --disable-avx2-kernels --enable-single-precision --disable-avx --disable-sse '
+local_commonopts += '--with-mpi=yes '
+
+configopts = local_commonopts
+#configopts = [
+#    local_commonopts + '--with-mpi=no ',
+#    local_commonopts + '--with-mpi=yes '
+#]
+
+prebuildopts = " make clean && "
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules',]
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s',
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/README.md
+++ b/easybuild/easyconfigs/e/ELPA/README.md
@@ -61,3 +61,8 @@ multithread version or the singlethread version?
 ### 2022.11 for cpeGNU 22.08
 
   * Trivial port of older EasyConfigs.
+
+### 2023.05.001 GPU for 22.12
+
+  * Supports GNU toolchain with ROCm (version agnostic)
+  * No support for OpenMP (conficts with GPU stream implementation) 

--- a/easybuild/easyconfigs/e/ELPA/elpa-2023.05.01.patch
+++ b/easybuild/easyconfigs/e/ELPA/elpa-2023.05.01.patch
@@ -1,0 +1,52 @@
+From 73cd34a2b9f2d3708812438092adb1b41f194841 Mon Sep 17 00:00:00 2001
+From: Maciej Szpindler <m.szpindler@uw.edu.pl>
+Date: Thu, 22 Jun 2023 13:27:16 +0300
+Subject: Minor code fixes
+
+---
+ src/GPU/ROCm/rocmFunctions_template.h | 4 ++--
+ src/GPU/check_for_gpu.F90             | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/GPU/ROCm/rocmFunctions_template.h b/src/GPU/ROCm/rocmFunctions_template.h
+index 8bc69bb4..2eb4ac1a 100644
+--- a/src/GPU/ROCm/rocmFunctions_template.h
++++ b/src/GPU/ROCm/rocmFunctions_template.h
+@@ -1562,7 +1562,7 @@ extern "C" {
+ 
+   void rocblasZscal_elpa_wrapper (BLAS_handle rocblasHandle, int n, double _Complex alpha, double _Complex *X, int incx){
+ 
+-#ifndef HIPBLAS
++#ifdef HIPBLAS
+     const BLAS_double_complex* X_casted = (const BLAS_double_complex*) X;
+ #else
+           BLAS_double_complex* X_casted = (      BLAS_double_complex*) X;
+@@ -1577,7 +1577,7 @@ extern "C" {
+ 
+   void rocblasCscal_elpa_wrapper (BLAS_handle rocblasHandle, int n, float _Complex alpha, float _Complex *X, int incx){
+ 
+-#ifndef HIPBLAS
++#ifdef HIPBLAS
+     const BLAS_float_complex* X_casted = (const BLAS_float_complex*) X;
+ #else
+           BLAS_float_complex* X_casted = (      BLAS_float_complex*) X;
+diff --git a/src/GPU/check_for_gpu.F90 b/src/GPU/check_for_gpu.F90
+index 18b372df..5e22f375 100644
+--- a/src/GPU/check_for_gpu.F90
++++ b/src/GPU/check_for_gpu.F90
+@@ -158,10 +158,10 @@ module mod_check_for_gpu
+ #ifdef WITH_AMD_ROCSOLVER
+       if (.not.(allocated(obj%gpu_setup%rocsolverHandleArray))) then
+         allocate(obj%gpu_setup%rocsolverHandleArray(0:maxThreads-1))
+-        allocate(obj%gpu_setup%gpucsolverHandleArray(0:maxThreads-1))
++        allocate(obj%gpu_setup%gpusolverHandleArray(0:maxThreads-1))
+         do thread=0, maxThreads-1
+           obj%gpu_setup%rocsolverHandleArray(thread) = -1
+-          obj%gpu_setup%gpucsolverHandleArray(thread) = -1
++          obj%gpu_setup%gpusolverHandleArray(thread) = -1
+         enddo
+       endif
+ #endif
+-- 
+2.35.3
+


### PR DESCRIPTION
This is a clean GPU recipe for the latest ELPA release. OpenMP not supported with AMD GPU stream implementation enabled.  