### PR TITLE
CP2K 2023.2 for CPE 22.12 with dependencies

### DIFF
--- a/easybuild/easyconfigs/c/COSMA/COSMA-2.6.6-cpeGNU-22.12-CPU.eb
+++ b/easybuild/easyconfigs/c/COSMA/COSMA-2.6.6-cpeGNU-22.12-CPU.eb
@@ -1,0 +1,57 @@
+# contributed by Peter Larsson (LUST)
+
+easyblock = 'CMakeMake'
+
+name =    'COSMA'
+version = '2.6.6'
+versionsuffix = '-CPU'
+
+homepage = 'https://github.com/eth-cscs/COSMA'
+
+whatis = [
+    "Description: COSMA is a parallel, high-performance, GPU-accelerated, matrix-matrix multiplication algorithm that is communication-optimal."
+]
+
+description = """
+COSMA is a parallel, high-performance, GPU-accelerated, matrix-matrix 
+multiplication algorithm that is communication-optimal for all combinations 
+of matrix dimensions, number of processors and memory sizes, without the 
+need for any parameter tuning. The key idea behind COSMA is to first derive 
+a tight optimal sequential schedule and only then parallelize it, preserving 
+I/O optimality between processes. 
+"""
+
+docurls = [
+    'Manual: https://github.com/eth-cscs/COSMA'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'opt': True}
+
+sources =     [{
+    'filename': SOURCELOWER_TAR_GZ,
+    'git_config': {
+        'url': 'https://github.com/eth-cscs',
+        'repo_name':'%(name)s',
+        'tag' :'v2.6.6',
+        'recursive': True,
+        'keep_git_dir' : True, },
+}]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True), # For CMake
+    ('bzip2',      '1.0.8'),
+]
+
+parallel = 16
+
+configopts = [
+    " -DCOSMA_BLAS=CRAY_LIBSCI -DCOSMA_SCALAPACK=CRAY_LIBSCI -DCOSMA_WITH_TESTS=NO -DCOSMA_WITH_BENCHMARKS=NO -DCMAKE_CXX_COMPILER=CC -DCOSMA_WITH_APPS=NO -DCOSMA_WITH_PROFILING=NO -DBUILD_SHARED_LIBS=NO ",
+]
+
+sanity_check_paths = {
+    'files': ['lib64/libcosma.a', 'lib64/libcosta.a'],
+    'dirs':  ['lib64'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2023.2-cpeGNU-22.12-CPU.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2023.2-cpeGNU-22.12-CPU.eb
@@ -1,0 +1,72 @@
+# contributed by Luca Marsella (CSCS)
+# modified for LUMI-G by Peter Larsson
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '2023.2'
+versionsuffix = '-CPU'
+
+homepage = 'http://www.cp2k.org/'
+
+whatis = [
+    'Description: CP2K is a program to perform atomistic and molecular simulations of solid state, liquid, molecular and biological systems.'
+]
+
+description = """
+CP2K is a freely available (GPL) program, written in Fortran 95, to
+perform atomistic and molecular simulations of solid state, liquid,
+molecular and biological systems. It provides a general framework for
+different methods such as e.g. density functional theory (DFT) using a
+mixed Gaussian and plane waves approach (GPW), and classical pair and
+many-body potentials.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    ('LUMIC-20232.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')
+]
+
+builddependencies = [('buildtools', '%(toolchain_version)s', '', True)]
+
+dependencies = [
+    ('ELPA', '2022.11.001','-CPU'),
+    ('Libint-CP2K', '2.6.0'),
+    ('libvori', '220621'),
+    ('libxc', '6.2.2'),
+    ('libxsmm', '1.17'),
+    ('spglib', '1.16.3'),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('COSMA','2.6.6','-CPU'),
+    ('GSL','2.7.1','-OpenMP'),
+    ('PLUMED','2.8.3','-noPython')
+]
+
+# build type
+#prebuildopts = 'module load craype-accel-amd-gfx90a && module load rocm/5.3.3 && '
+buildopts = "ARCH=LUMIC-20232 VERSION=psmp"
+
+files_to_copy = [
+    (['./arch/LUMIC-20232.psmp'], 'arch'),
+    (['./exe/LUMIC-20232/*'], 'bin'),
+    (['./data'], '.'),
+    (['./tests'], '.'),
+    (['./tools'], '.')
+]
+
+sanity_check_paths = {
+    'files': ['arch/LUMIC-20232.psmp', 'bin/%(namelower)s.psmp'],
+    'dirs': ['data', 'tests'],
+}
+
+parallel = 16
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'
+

--- a/easybuild/easyconfigs/c/CP2K/LUMIC-20232.psmp
+++ b/easybuild/easyconfigs/c/CP2K/LUMIC-20232.psmp
@@ -1,0 +1,60 @@
+include $(EBROOTPLUMED)/lib/plumed/src/lib/Plumed.inc
+
+CC          = cc
+CXX         = CC
+AR          = ar -r
+FC          = ftn
+LD          = ftn
+#
+DFLAGS      = -D__LIBXSMM  -D__SCALAPACK -D__parallel -D__FFTW3  -D__LIBINT -D__LIBXC -D__COSMA -D__ELPA  -D__GSL -D__HDF5 -D__SPGLIB -D__LIBVORI -D__PLUMED2
+#
+WFLAGS      = -Werror=aliasing -Werror=ampersand -Werror=c-binding-type -Werror=intrinsic-shadow -Werror=intrinsics-std -Werror=line-truncation -Werror=tabs -Werror=target-lifetime -Werror=underflow -Werror=unused-but-set-variable -Werror=unused-variable -Werror=unused-dummy-argument -Werror=conversion -Werror=zerotrip -Wno-maybe-uninitialized -Wuninitialized -Wuse-without-only 
+#
+FCDEBFLAGS  = -fbacktrace -ffree-form -fimplicit-none -std=f2008 
+
+CFLAGS = -fno-omit-frame-pointer -fopenmp -g -mtune=native -O3 -funroll-loops -std=c11 -Wall -Wextra -Werror -Wno-vla-parameter -Wno-deprecated-declarations  $(DFLAGS)
+CLFAGS += -I($ROCM_PATH)/include
+CFLAGS += -I$(FFTW_INC)
+CFLAGS += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
+CFLAGS += -I$(EBROOTLIBXC)/include
+CFLAGS += -I$(EBROOTLIBXSMM)/include
+CFLAGS += -I$(EBROOTCOSMA)/include
+CFLAGS += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
+CFLAGS += -I$(EBROOTGSL)/include
+# HDF5?
+CFLAGS += -I$(EBROOTSPGLIB)/include
+#CFLAGS += -I$(EBROOTSPFFT)/include
+#CFLAGS += -I$(EBROOTSPLA)/include
+
+FCFLAGS     = -fno-omit-frame-pointer -fopenmp -g -mtune=native  -O3 -funroll-loops -fallow-argument-mismatch  $(FCDEBFLAGS) $(WFLAGS) $(DFLAGS)
+FCFLAGS += -I$(ROCM_PATH)/include
+FCFLAGS += -I$(FFTW_INC)
+FCFLAGS += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
+FCFLAGS += -I$(EBROOTLIBXC)/include
+FCFLAGS += -I$(EBROOTLIBXSMM)/include
+FCFLAGS += -I$(EBROOTCOSMA)/include
+FCFLAGS += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
+FCFLAGS += -I$(EBROOTGSL)/include
+# HDF5?
+FCFLAGS += -I$(EBROOTSPGLIB)/include
+#FCFLAGS += -I$(EBROOTSPFFT)/include
+#FCFLAGS += -I$(EBROOTSPLA)/include/spla
+
+CXXFLAGS    = -O2 -fPIC -fno-omit-frame-pointer -fopenmp -g -march=native -mtune=native --std=c++14 $(DFLAGS) -Wno-deprecated-declarations -fopenmp -Wall -Wextra -Werror -I$(ROCM_PATH)/include
+#
+LDFLAGS =  $(FCFLAGS) -Wl,--enable-new-dtags
+LDFLAGS += -I$(EBROOTGSL)/lib
+LDFLAGS += -L$(EBROOTFFTW)/lib
+LDFLAGS += -L$(EBROOTLIBINTMINCP2K)/lib
+LDFLAGS += -L$(EBROOTLIBXC)/lib
+LDFLAGS += -L$(EBROOTLIBXSMM)/lib
+LDFLAGS += -L$(EBROOTCOSMA)/lib
+LDFLAGS += -L$(EBROOTELPA)/lib
+LDFLAGS += -L$(EBROOTGSL)/lib
+LDFLAGS += -L$(EBROOTSPGLIB)/lib
+LDFLAGS += -L$(EBROOTLIBVORI)/lib
+LDFLAGS += -I$(EBROOTSPFFT)/lib
+LDFLAGS += -I$(EBROOTSPLA)/lib
+
+LIBS        = -lsymspg -lhdf5 -lhdf5_hl -lz -lgsl -lelpa -lcosma_prefixed_pxgemm -lcosma -lcosta -lxsmmf -lxsmm -ldl -lpthread -lxcf03 -lxc -lint2 -lfftw3_mpi -lfftw3 -lfftw3_omp -lplumed -lz -ldl -lvori -lstdc++ 
+#

--- a/easybuild/easyconfigs/c/CP2K/README.md
+++ b/easybuild/easyconfigs/c/CP2K/README.md
@@ -24,3 +24,6 @@
     the unsupported `rocm/5.3.3` module installed by the LUMI Support Team, as CP2K requires at ROCm 5.3.3.
 -   `CP2K-2023.1-cpeGNU-22.12-CPU.eb`: A CPU-only build of CP2K release 2023.1 compiled with the GNU compilers
     and with support for PLUMED.
+-   `CP2K-2023.2-cpeGNU-22.12-CPU.eb`: A CPU-only build of CP2K release 2023.2 compiled with the GNU compilers
+    and with support for PLUMED.
+

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-22.12.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-22.12.eb
@@ -1,0 +1,57 @@
+# contributed by Luca Marsella (CSCS)
+# adapated for LUMI by Peter Larsson
+
+local_bzip2_version = '1.0.8'
+
+easyblock = 'CMakeMake'
+
+name =    'libxc'
+version = '6.2.2'
+homepage = 'https://www.tddft.org/programs/libxc/'
+
+whatis = [
+    "Description: Libxc is a library of exchange-correlation and kinetic energy functionals " 
+    "for density-functional theory."
+]
+
+description = """
+Libxc is a library of exchange-correlation and kinetic energy functionals for 
+density-functional theory. The original aim was to provide a portable, well 
+tested and reliable set of LDA, GGA, and meta-GGA functionals.
+
+Libxc is written in C, but it also comes with Fortran binding. 
+
+It is released under the MPL license (v. 2.0). In all publications resulting 
+from your use of Libxc, please cite:
+
+[ref] Susi Lehtola, Conrad Steigemann, Micael J. T. Oliveira, and Miguel A. L. Marques, 
+      "Recent developments in Libxc - A comprehensive  library of functionals for 
+      density functional theory", Software X 7, 1 (2018)
+"""
+
+docurls = [
+    'Manual: https://www.tddft.org/programs/libxc/manual/',
+    'Available functionals: https://www.tddft.org/programs/libxc/functionals/'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
+sources = [SOURCE_TAR_BZ2]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True), # For CMake
+    ('bzip2',      local_bzip2_version),
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON ",
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.so', 'lib/%(name)sf90.so', 'lib/%(name)sf03.so'],
+    'dirs':  ['include'],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Rebuilt and adapated the 2023.1 EB recipe for version 2023.2. This required reworking the COSMA EB file too. Updated the user documentation to reflect the new SLURM configuration for LUMI-G.