### PR TITLE
NAMD3 beta GPU resident version with Charm++

### DIFF
--- a/easybuild/easyconfigs/c/Charm++/Charm++-7.0.0-cpeGNU-22.12-multicore.eb
+++ b/easybuild/easyconfigs/c/Charm++/Charm++-7.0.0-cpeGNU-22.12-multicore.eb
@@ -1,0 +1,65 @@
+# contributed by Luca Marsella and Jean-Guillaume Piccinali (CSCS)
+# Adapted by Kurt Lust (kurt.lust@uantwerpen.be) for the LUMI consortium
+# Adapted by Pierre Beaujean (pierre.beaujean@unamur.be) for 22.08
+
+easyblock = 'CmdCp'
+
+name =          'Charm++'
+version =       '7.0.0'
+versionsuffix = '-multicore'
+
+homepage = 'http://charm.cs.illinois.edu/research/charm/'
+
+whatis = [
+    'Charm++ is a machine independent parallel programming system.'
+]
+
+description = """
+Charm++ is a machine independent parallel programming system. Programs
+written using this system will run unchanged on MIMD machines with or
+without a shared memory.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'dynamic': False}
+
+source_urls = ['http://charm.cs.illinois.edu/distrib/']
+sources = ['charm-%(version)s.tar.gz']
+
+builddependencies = [
+    ('buildtools',   '%(toolchain_version)s', '', True),
+]
+
+local_charmpp_arch = 'multicore-linux-x86_64'
+local_charmpp_comp = 'gcc'
+local_charmpp_type = f'{local_charmpp_arch}-{local_charmpp_comp}'
+
+local_config_and_build  = f' ./build charm++ {local_charmpp_arch} {local_charmpp_comp}'
+local_config_and_build += ' --build-shared'
+local_config_and_build += ' --with-production'
+local_config_and_build += ' -j12'
+
+cmds_map = [
+    ('charm-%(version)s.tar.gz', local_config_and_build),
+]
+
+files_to_copy = [local_charmpp_type]
+
+sanity_check_paths = {
+    'files': [f'{local_charmpp_type}/bin/charmc'],
+    'dirs':  [
+      f'{local_charmpp_type}/bin', 
+      f'{local_charmpp_type}/lib', 
+      f'{local_charmpp_type}/include'
+    ],
+}
+
+modextrapaths = {
+    'PATH': f'{local_charmpp_type}/bin'
+}
+
+modextravars = {
+    'EBTYPECHARMPLUSPLUS': f'{local_charmpp_type}'
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0b4-cpeGNU-22.12-resident-GPU.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0b4-cpeGNU-22.12-resident-GPU.eb
@@ -1,0 +1,107 @@
+# Contributed by Guilherme Peretti Pezzi, Luca Marsella and Christopher Bignamini (CSCS)
+# Adapted by Kurt Lust (kurt.lust@uantwerpen.be) for the LUMI consortium
+# Adapted by Pierre Beaujean (pierre.beaujean@unamur.be) for 22.08
+
+easyblock = 'MakeCp'
+
+name =          'NAMD'
+version =       '3.0b4'
+versionsuffix = '-resident-GPU'
+
+homepage = 'http://www.ks.uiuc.edu/Research/namd/'
+
+whatis = [
+    "Description: NAMD is a parallel molecular dynamics code designed for "
+    "high-performance simulation of large biomolecular systems."
+]
+
+description = """
+NAMD, recipient of a 2002 Gordon Bell Award and a 2012 Sidney Fernbach Award,
+is a parallel molecular dynamics code designed for high-performance simulation
+of large biomolecular systems. Based on Charm++ parallel objects, NAMD scales
+to hundreds of cores for typical simulations and beyond 500,000 cores for the
+largest simulations. NAMD uses the popular molecular graphics program VMD for
+simulation setup and trajectory analysis, but is also file-compatible with
+AMBER, CHARMM, and X-PLOR.
+
+This version of NAMD is compiled with MPI as the transport.
+
+Please check the NAMD license at https://www.ks.uiuc.edu/Research/namd/license.html
+before installing or using this software. In particular, this software is only free
+for non-commercial research and teaching. All commercial use requires a commercial
+license. Also, when installing this as part of a project, all users should explictly
+register on the NAMD web site (e.g., by trying to download the sources from
+https://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=NAMD).
+
+Please also note article 6 of the LICENSE:
+
+    The user agrees that any reports or published results obtained with
+    the Software will acknowledge its use by the appropriate citation as
+    follows:
+
+    "NAMD was developed by the Theoretical and Computational Biophysics Group in
+     the Beckman Institute for Advanced Science and Technology at the University
+     of Illinois at Urbana-Champaign."
+
+    Any published work which utilizes NAMD shall include the following reference:
+
+    "James C. Phillips, David J. Hardy, Julio D. C. Maia, John E. Stone,
+     Joao V. Ribeiro, Rafael C. Bernardi, Ronak Buch, Giacomo Fiorin,
+     Jerome Henin, Wei Jiang, Ryan McGreevy, Marcelo C. R. Melo,
+     Brian K. Radak, Robert D. Skeel, Abhishek Singharoy, Yi Wang, Benoit Roux,
+     Aleksei Aksimentiev, Zaida Luthey-Schulten, Laxmikant V. Kale,
+     Klaus Schulten, Christophe Chipot, and Emad Tajkhorshid.
+     Scalable molecular dynamics on CPU and GPU architectures with NAMD.
+     Journal of Chemical Physics, 153:044130, 2020. doi:10.1063/5.0014475"
+
+    Electronic documents will include a direct link to the official NAMD page
+    at http://www.ks.uiuc.edu/Research/namd/
+"""
+
+docurls = [
+    'NAMD %(version)s User Guide: http://www.ks.uiuc.edu/Research/namd/%(version)s/ug/',
+    'NAMD Wiki: http://www.ks.uiuc.edu/Research/namd/wiki/',
+    'NAMD license: $EBROOTNAMD/license.txt'
+]
+
+upstream_contacts = [
+    'NAMD Mailing List/forum: http://www.ks.uiuc.edu/Research/namd/mailing_list/',
+    'NAMD bug report instructions: http://www.ks.uiuc.edu/Research/namd/bugreport.html',
+]
+
+docpaths = [ 'notes.txt' ]
+
+toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchainopts = {'openmp': True}
+
+sources = ['NAMD_%(version)s_Source.tar.gz']
+
+builddependencies = [
+    ('cray-fftw',    EXTERNAL_MODULE),
+    ('rocm', EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('Charm++', '7.0.0', '-multicore'),
+]
+
+local_namd_arch = 'Linux-x86_64-g++'
+
+prebuildopts  = f'./config {local_namd_arch} '
+prebuildopts += '--charm-arch $EBTYPECHARMPLUSPLUS --charm-base $EBROOTCHARMPLUSPLUS '
+prebuildopts += '--with-single-node-hip --with-hip --rocm-prefix $ROCM_PATH '
+prebuildopts += '--without-tcl '
+prebuildopts += '--with-fftw3 --fftw-prefix $FFTW_ROOT '
+prebuildopts += '--charm-opts "-fopenmp" '
+prebuildopts += f'&& cd {local_namd_arch} && ' 
+
+files_to_copy = [
+    ([f'./{local_namd_arch}/namd3'], 'bin')
+]
+
+sanity_check_paths = {
+    'files': ['bin/namd3'],
+    'dirs':  [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0b6-cpeAMD-23.09-rocm-5.6.1.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0b6-cpeAMD-23.09-rocm-5.6.1.eb
@@ -5,8 +5,8 @@
 easyblock = 'MakeCp'
 
 name =          'NAMD'
-version =       '3.0b4'
-versionsuffix = '-resident-GPU'
+version =       '3.0b6'
+versionsuffix = '-rocm-5.6.1'
 
 homepage = 'http://www.ks.uiuc.edu/Research/namd/'
 
@@ -71,29 +71,40 @@ upstream_contacts = [
 
 docpaths = [ 'notes.txt' ]
 
-toolchain = {'name': 'cpeGNU', 'version': '22.12'}
+toolchain = {'name': 'cpeAMD', 'version': '23.09'}
 toolchainopts = {'openmp': True}
 
 sources = ['NAMD_%(version)s_Source.tar.gz']
 
+patches = [
+    'namd3-arch-rocm-clang.patch'
+]
+
 builddependencies = [
-    ('cray-fftw',    EXTERNAL_MODULE),
-    ('rocm', EXTERNAL_MODULE),
+    ('buildtools',   '%(toolchain_version)s',   '', True),
 ]
 
 dependencies = [
+    ('cray-fftw/3.3.10.5',    EXTERNAL_MODULE),
+    ('amd', '5.6.1', '', SYSTEM),
+    ('rocm', '5.6.1', '', SYSTEM),
     ('Charm++', '7.0.0', '-multicore'),
+    ('Tcl', '8.6.13'),
 ]
 
-local_namd_arch = 'Linux-x86_64-g++'
+local_namd_arch = 'Linux-x86_64-clang++'
 
 prebuildopts  = f'./config {local_namd_arch} '
-prebuildopts += '--charm-arch $EBTYPECHARMPLUSPLUS --charm-base $EBROOTCHARMPLUSPLUS '
-prebuildopts += '--with-single-node-hip --with-hip --rocm-prefix $ROCM_PATH '
-prebuildopts += '--without-tcl '
+prebuildopts += '--charm-arch $EBTYPECHARMPLUSPLUS '
+prebuildopts += '--charm-base $EBROOTCHARMPLUSPLUS '
+prebuildopts += '--with-single-node-hip ' 
+prebuildopts += '--with-hip '
+prebuildopts += '--rocm-prefix $ROCM_PATH '
 prebuildopts += '--with-fftw3 --fftw-prefix $FFTW_ROOT '
 prebuildopts += '--charm-opts "-fopenmp" '
 prebuildopts += f'&& cd {local_namd_arch} && ' 
+
+build_cmd_targets = 'ROCM_DIR=$ROCM_PATH HIP_PLATFORM=amd'
 
 files_to_copy = [
     ([f'./{local_namd_arch}/namd3'], 'bin')

--- a/easybuild/easyconfigs/n/NAMD/README.md
+++ b/easybuild/easyconfigs/n/NAMD/README.md
@@ -19,3 +19,9 @@ file-compatible with AMBER, CHARMM, and X-PLOR.
 ### Version 2.14 for CPE GNU 21.08
 
   * The EasyConfig is derived from the CSCS one
+
+### Version 3.0b6 GPU resident for CPE AMD 23.09
+
+  * Works with a single node runs only - uses multicore Charm++ runtime (no MPI)
+  * Beta release of the code
+  * Uses ROCm 5.6.1 not fully supported with CPE 23.09 

--- a/easybuild/easyconfigs/n/NAMD/namd3-arch-rocm-clang.patch
+++ b/easybuild/easyconfigs/n/NAMD/namd3-arch-rocm-clang.patch
@@ -1,0 +1,199 @@
+diff -Naur namd-release-3-0-beta-6/Make.depends namd-release-3-0-beta-6-lumi/Make.depends
+--- namd-release-3-0-beta-6/Make.depends	2024-01-20 18:21:50.000000000 +0200
++++ namd-release-3-0-beta-6-lumi/Make.depends	2024-03-05 17:35:03.000000000 +0200
+@@ -9445,7 +9445,7 @@
+ 	src/Tensor.h \
+ 	src/ComputeBondedCUDAKernel.h \
+ 	src/CudaNonbondedTables.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/MigrationBondedCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`MigrationBondedCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/MigrationBondedCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`MigrationBondedCUDAKernel.cu
+ obj/MigrationCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/MigrationCUDAKernel.cu \
+@@ -9465,7 +9465,7 @@
+ 	src/CudaNonbondedTables.h \
+ 	src/CudaComputeNonbondedKernel.hip.h \
+ 	src/CudaTileListKernel.hip.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/MigrationCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`MigrationCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/MigrationCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`MigrationCUDAKernel.cu
+ obj/SequencerCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/SequencerCUDAKernel.cu \
+@@ -9483,7 +9483,7 @@
+ 	src/CudaTileListKernel.hip.h \
+ 	src/Lattice.h \
+ 	src/Tensor.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/SequencerCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`SequencerCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/SequencerCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`SequencerCUDAKernel.cu
+ obj/ComputeBondedCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputeBondedCUDAKernel.cu \
+@@ -9500,14 +9500,14 @@
+ 	src/CudaNonbondedTables.h \
+ 	src/CudaComputeNonbondedInteractions.h \
+ 	src/DeviceCUDA.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputeBondedCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeBondedCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputeBondedCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeBondedCUDAKernel.cu
+ obj/ComputePmeCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputePmeCUDAKernel.cu \
+ 	src/ComputePmeCUDAKernel.h \
+ 	src/HipDefines.h \
+ 	src/CudaUtils.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputePmeCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputePmeCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputePmeCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputePmeCUDAKernel.cu
+ obj/ComputeRestraintsCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputeRestraintsCUDAKernel.cu \
+@@ -9522,7 +9522,7 @@
+ 	src/ResizeArrayRaw.h \
+ 	src/Tensor.h \
+ 	src/CudaUtils.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputeRestraintsCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeRestraintsCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputeRestraintsCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeRestraintsCUDAKernel.cu
+ obj/ComputeSMDCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputeSMDCUDAKernel.cu \
+@@ -9538,7 +9538,7 @@
+ 	src/Tensor.h \
+ 	src/CudaUtils.h \
+ 	src/ComputeCOMCudaKernel.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputeSMDCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeSMDCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputeSMDCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeSMDCUDAKernel.cu
+ obj/ComputeGroupRes1GroupCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputeGroupRes1GroupCUDAKernel.cu \
+@@ -9554,7 +9554,7 @@
+ 	src/Tensor.h \
+ 	src/CudaUtils.h \
+ 	src/ComputeCOMCudaKernel.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputeGroupRes1GroupCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeGroupRes1GroupCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputeGroupRes1GroupCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeGroupRes1GroupCUDAKernel.cu
+ obj/ComputeGroupRes2GroupCUDAKernel.o: \
+ 	obj/.exists \
+ 	src/ComputeGroupRes2GroupCUDAKernel.cu \
+@@ -9570,7 +9570,7 @@
+ 	src/Tensor.h \
+ 	src/CudaUtils.h \
+ 	src/ComputeCOMCudaKernel.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/ComputeGroupRes2GroupCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeGroupRes2GroupCUDAKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/ComputeGroupRes2GroupCUDAKernel.o $(COPTC) `$(NATIVEPATH) src/`ComputeGroupRes2GroupCUDAKernel.cu
+ obj/CudaComputeGBISKernel.o: \
+ 	obj/.exists \
+ 	src/CudaComputeGBISKernel.cu \
+@@ -9581,7 +9581,7 @@
+ 	src/CudaTileListKernel.hip.h \
+ 	src/DeviceCUDA.h \
+ 	src/ComputeGBIS.inl
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaComputeGBISKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeGBISKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaComputeGBISKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeGBISKernel.cu
+ obj/CudaComputeNonbondedKernel.o: \
+ 	obj/.exists \
+ 	src/CudaComputeNonbondedKernel.cu \
+@@ -9593,7 +9593,7 @@
+ 	src/CudaNonbondedTables.h \
+ 	src/DeviceCUDA.h \
+ 	src/CudaComputeNonbondedInteractions.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaComputeNonbondedKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeNonbondedKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaComputeNonbondedKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeNonbondedKernel.cu
+ obj/CudaComputeNonbondedKernelHip.o: \
+ 	obj/.exists \
+ 	src/CudaComputeNonbondedKernelHip.cu \
+@@ -9604,14 +9604,14 @@
+ 	src/CudaTileListKernel.hip.h \
+ 	src/CudaNonbondedTables.h \
+ 	src/DeviceCUDA.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaComputeNonbondedKernelHip.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeNonbondedKernelHip.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaComputeNonbondedKernelHip.o $(COPTC) `$(NATIVEPATH) src/`CudaComputeNonbondedKernelHip.cu
+ obj/CudaPmeSolverUtilKernel.o: \
+ 	obj/.exists \
+ 	src/CudaPmeSolverUtilKernel.cu \
+ 	src/HipDefines.h \
+ 	src/CudaUtils.h \
+ 	src/CudaPmeSolverUtilKernel.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaPmeSolverUtilKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaPmeSolverUtilKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaPmeSolverUtilKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaPmeSolverUtilKernel.cu
+ obj/CudaTileListKernel.o: \
+ 	obj/.exists \
+ 	src/CudaTileListKernel.cu \
+@@ -9622,7 +9622,7 @@
+ 	src/CudaRecord.h \
+ 	src/CudaNonbondedTables.h \
+ 	src/DeviceCUDA.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaTileListKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaTileListKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaTileListKernel.o $(COPTC) `$(NATIVEPATH) src/`CudaTileListKernel.cu
+ obj/CudaTileListKernelHip.o: \
+ 	obj/.exists \
+ 	src/CudaTileListKernelHip.cu \
+@@ -9630,13 +9630,13 @@
+ 	src/HipDefines.h \
+ 	src/CudaTileListKernel.hip.h \
+ 	src/DeviceCUDA.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/CudaTileListKernelHip.o $(COPTC) `$(NATIVEPATH) src/`CudaTileListKernelHip.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/CudaTileListKernelHip.o $(COPTC) `$(NATIVEPATH) src/`CudaTileListKernelHip.cu
+ obj/DeviceCUDAkernel.o: \
+ 	obj/.exists \
+ 	src/DeviceCUDAkernel.cu \
+ 	src/CudaUtils.h \
+ 	src/HipDefines.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/DeviceCUDAkernel.o $(COPTC) `$(NATIVEPATH) src/`DeviceCUDAkernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/DeviceCUDAkernel.o $(COPTC) `$(NATIVEPATH) src/`DeviceCUDAkernel.cu
+ obj/MShakeKernel.o: \
+ 	obj/.exists \
+ 	src/MShakeKernel.cu \
+@@ -9644,7 +9644,7 @@
+ 	src/MShakeKernel.h \
+ 	src/CudaUtils.h \
+ 	src/HipDefines.h
+-	$(CUDACC) $(CUDACCOPTS) -Xptxas -v $(COPTO)obj/MShakeKernel.o $(COPTC) `$(NATIVEPATH) src/`MShakeKernel.cu
++	$(CUDACC) $(CUDACCOPTS)  -v $(COPTO)obj/MShakeKernel.o $(COPTC) `$(NATIVEPATH) src/`MShakeKernel.cu
+ obj/dcdplugin.o: \
+ 	obj/.exists \
+ 	plugins/molfile_plugin/src/dcdplugin.c \
+diff -Naur namd-release-3-0-beta-6/arch/Linux-x86_64-clang++.arch namd-release-3-0-beta-6-lumi/arch/Linux-x86_64-clang++.arch
+--- namd-release-3-0-beta-6/arch/Linux-x86_64-clang++.arch	1970-01-01 02:00:00.000000000 +0200
++++ namd-release-3-0-beta-6-lumi/arch/Linux-x86_64-clang++.arch	2024-03-05 17:30:00.000000000 +0200
+@@ -0,0 +1,8 @@
++NAMD_ARCH = Linux-x86_64
++CHARMARCH = multicore-linux-x86_64
++
++CXX = amdclang++ -m64 -std=c++0x
++CXXOPTS = -O3 -fexpensive-optimizations -ffast-math 
++CC = amdclang -m64
++COPTS = -O3 -fexpensive-optimizations -ffast-math
++
+diff -Naur namd-release-3-0-beta-6/arch/Linux-x86_64.hip namd-release-3-0-beta-6-lumi/arch/Linux-x86_64.hip
+--- namd-release-3-0-beta-6/arch/Linux-x86_64.hip	2024-01-20 18:21:50.000000000 +0200
++++ namd-release-3-0-beta-6-lumi/arch/Linux-x86_64.hip	2024-03-05 17:32:54.000000000 +0200
+@@ -25,7 +25,7 @@
+     #The (optional) --amdgpu-target directives are useful for cross-compiling to different AMD architectures.
+     HIPCCOPTS += -march=native -ffast-math -fno-gpu-rdc -fcuda-flush-denormals-to-zero -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -Wno-invalid-constexpr -Wno-ignored-optimization-argument
+     HIPCCOPTS += -Wno-unused-private-field
+-    HIPCCOPTS += -fdenormal-fp-math=ieee -munsafe-fp-atomics --offload-arch=gfx906,gfx908,gfx90a,gfx1030 -fno-slp-vectorize
++    HIPCCOPTS += -fdenormal-fp-math=ieee -munsafe-fp-atomics --offload-arch=gfx90a -fno-slp-vectorize
+ 
+ else
+     # include CUB
+@@ -41,9 +41,9 @@
+ ifneq ($(PLATFORM),nvcc)
+     #ROCM version 3.3 was the last one to use the old hcc compiler.
+     ifeq ($(ROCMV),3.3)
+-    	CUDALIB = -L$(HIPDIR)/lib -lhip_hcc -lhipfft -lhiprand -lroctx64 -lroctracer64
++    	CUDALIB = -L$(HIPDIR)/lib -lhip_hcc -lhipfft -lhiprand -lrocm_smi64 -lroctx64 $(PE_MPICH_GTL_DIR_amd_gfx90a) $(PE_MPICH_GTL_LIBS_amd_gfx90a) -lroctracer64
+     else
+-    	CUDALIB = -L$(HIPDIR)/lib -lamdhip64 -lhipfft -lrocfft -lhiprand -lroctx64 -lroctracer64
++    	CUDALIB = -L$(HIPDIR)/lib -lamdhip64 -lhipfft -lrocfft -lhiprand -lrocm_smi64 -lroctx64 $(PE_MPICH_GTL_DIR_amd_gfx90a) $(PE_MPICH_GTL_LIBS_amd_gfx90a) -lroctracer64
+     endif
+     # CHARMLD = -ld++ $(HIPCC)
+     CUDAFLAGS += -I$(HIPDIR)/include -I$(HIPDIR)/include/hipfft -I$(HIPDIR)/include/rocfft -I$(HIPDIR)/include/hiprand -I$(HIPDIR)/include/rocrand -I$(HIPDIR)/include/roctracer #-DDISABLE_P2P
+diff -Naur namd-release-3-0-beta-6/arch/Linux-x86_64.tcl namd-release-3-0-beta-6-lumi/arch/Linux-x86_64.tcl
+--- namd-release-3-0-beta-6/arch/Linux-x86_64.tcl	2024-01-20 18:21:50.000000000 +0200
++++ namd-release-3-0-beta-6-lumi/arch/Linux-x86_64.tcl	2024-03-05 17:33:38.000000000 +0200
+@@ -1,6 +1,6 @@
+ 
+ #TCLDIR=/Projects/namd2/tcl/tcl8.5.9-linux-x86_64
+-TCLDIR=/Projects/namd2/tcl/tcl8.6.13-linux-x86_64-threaded
++TCLDIR=$(EBROOTTCL)
+ TCLINCL=-I$(TCLDIR)/include
+ #TCLLIB=-L$(TCLDIR)/lib -ltcl8.5 -ldl
+ TCLLIB=-L$(TCLDIR)/lib -ltcl8.6 -ldl -lpthread


### PR DESCRIPTION
This is recipe for NAMD 3.0b4 GPU resident build only. Supports only single node (no MPI at all) with Charm++ v7.0.0 multicore. Fails to build with `buildtools`. Not able to detect GPU P2P (hip) for unknown reason.