### PR TITLE
Update VASP

### DIFF
--- a/easybuild/easyconfigs/d/DFTD4/DFTD4-3.6.0-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/d/DFTD4/DFTD4-3.6.0-cpeGNU-23.09.eb
@@ -1,0 +1,65 @@
+# adapted for LUMI by Pierre Beaujean
+
+easyblock = 'MesonNinja'
+
+name = 'DFTD4'
+version = '3.6.0'
+
+homepage= 'https://github.com/dftd4/dftd4'
+
+whatis = [
+    'Description: DFTD4: Generally Applicable Atomic-Charge Dependent London Dispersion Correction'
+]
+
+description = """
+Generally Applicable Atomic-Charge Dependent London Dispersion Correction.
+
+Citation
+========
+The authors of the package ask to always cite the following papers:
+
+Eike Caldeweyher, Christoph Bannwarth and Stefan Grimme, J. Chem. Phys., 2017,
+147, 034112. DOI: 10.1063/1.4993215
+
+Eike Caldeweyher, Sebastian Ehlert, Andreas Hansen, Hagen Neugebauer, Sebastian
+Spicher, Christoph Bannwarth and Stefan Grimme, J. Chem Phys, 2019, 150, 154122.
+DOI: 10.1063/1.5090222 chemrxiv: 10.26434/chemrxiv.7430216
+
+Eike Caldeweyher, Jan-Michael Mewes, Sebastian Ehlert and Stefan Grimme, Phys. Chem.
+Chem. Phys., 2020, 22, 8499-8512. DOI: 10.1039/D0CP00502A
+chemrxiv: 10.26434/chemrxiv.10299428
+
+License
+=======
+This project is free software: you can redistribute it and/or modify it under the
+terms of the Lesser GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+github_account = 'dftd4'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['0e3e8d5f9e9e5414b9979967c074c953706053832e551d922c27599e7324bace']
+
+builddependencies = [('buildtools-python', '%(toolchain_version)s', '-systemPython', True),('buildtools', '%(toolchain_version)s', '', True)]
+
+preconfigopts = 'export FC=ftn && export CC=cc &&'
+# use custom BLAS... And trick the DFTD4's meson.build by providing an empty lib!
+configopts = "-Dlapack=custom -Dcustom_libraries='-L'"
+# add V2 for VASP
+configopts += ' -Dapi_v2=true '
+# release build type
+configopts += "--buildtype release "
+
+sanity_check_paths = {
+	'files' : ['bin/dftd4','lib/libdftd4.a','include/dftd4.h'],
+	'dirs' : ['bin','lib64','include']
+}
+
+sanity_check_commands = ["dftd4 --version"]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-23.09-nofhc.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-23.09-nofhc.eb
@@ -1,0 +1,59 @@
+# contributed by Luca Marsella (CSCS)
+# adapated for LUMI by Peter Larsson and Pierre Beaujean
+
+local_bzip2_version = '1.0.8'
+
+easyblock = 'CMakeMake'
+
+name =    'libxc'
+version = '6.2.2'
+versionsuffix = '-nofhc'
+homepage = 'https://www.tddft.org/programs/libxc/'
+
+whatis = [
+    "Description: Libxc is a library of exchange-correlation and kinetic energy functionals " 
+    "for density-functional theory."
+]
+
+description = """
+Libxc is a library of exchange-correlation and kinetic energy functionals for 
+density-functional theory. The original aim was to provide a portable, well 
+tested and reliable set of LDA, GGA, and meta-GGA functionals.
+
+Libxc is written in C, but it also comes with Fortran binding. 
+
+It is released under the MPL license (v. 2.0). In all publications resulting 
+from your use of Libxc, please cite:
+
+[ref] Susi Lehtola, Conrad Steigemann, Micael J. T. Oliveira, and Miguel A. L. Marques, 
+      "Recent developments in Libxc - A comprehensive  library of functionals for 
+      density functional theory", Software X 7, 1 (2018)
+"""
+
+docurls = [
+    'Manual: https://www.tddft.org/programs/libxc/manual/',
+    'Available functionals: https://www.tddft.org/programs/libxc/functionals/'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['ec292de621e819b03a37db1f7a7365a9eaf423e30e2fd4553e6336eca534cc29']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True), # For CMake
+    ('bzip2',      local_bzip2_version),
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON -DDISABLE_FHC=ON ",
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.so', 'lib/%(name)sf90.so', 'lib/%(name)sf03.so'],
+    'dirs':  ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/v/VASP/USER.md
+++ b/easybuild/easyconfigs/v/VASP/USER.md
@@ -10,37 +10,36 @@
 # VASP on LUMI
 
 [VASP (Vienna Ab Initio Simulation Package)][vasp] is a popular software
-package for "atomic scale materials modelling from first principles". In
+package for "atomic scale materials modeling from first principles". In
 general, it runs well on [LUMI-C][lumi-c].
 
-**There is currently no version of VASP that can use the AMD GPUs in the [GPU
-Early Access Platform][eap] or [LUMI-G][lumi-g].**
+**There is currently no version of VASP that can use the AMD GPUs in the [GPU Early Access Platform][eap] or [LUMI-G][lumi-g].**
 
 ## Installing VASP
 
-We provide automatic installation scripts for several versions of VASP. In
+We provide automatic installation scripts for several versions of VASP (see [below](#description-of-the-different-vasp-builds)). In
 general, the installation procedure is described on the [EasyBuild
 page][EasyBuild]. The step by step procedure to install VASP
-6.4.1 is:
+6.4.2 is:
 
-1. Download the VASP source code "vasp.6.4.1.tgz" from the [VASP portal][vasp].
+1. Download the VASP source code "vasp.6.4.2.tgz" from the [VASP portal][vasp].
 2. Upload the file somewhere to your home directory on LUMI.
-3. Load the LUMI software environment: `module load LUMI/22.12`.
+3. Load the LUMI software environment: `module load LUMI/23.09`.
 4. Select the LUMI-C partition: `module load partition/C`.
 5. Load the EasyBuild module: `module load EasyBuild-user`.
 
 Then, you can run the install command:
 
 ```bash
-$ eb --sourcepath=<directory-where-the-VASP-source-is-stored> VASP-6.4.1-cpeGNU-22.12-build02.eb -r
+$ eb --sourcepath=<directory-where-the-VASP-source-is-stored> VASP-6.4.2-cpeGNU-23.09.eb -r
 ```
 
 The installation process is quite slow. It will take about 20 minutes, but
-afterwards, you will have a module called "VASP/6.4.1-cpeGNU-22.12" installed
+afterwards, you will have a module called "VASP/6.4.2-cpeGNU-23.09" installed
 in your home directory. Load the module to use it
 
 ```bash
-$ module load VASP/6.4.1-cpeGNU-22.12-build02
+$ module load VASP/6.4.2-cpeGNU-23.09
 ```
 
 The usual VASP binaries, `vasp_std`, `vasp_gam` etc. will now be in your
@@ -56,7 +55,7 @@ same way by running the EasyBuild command
 $ eb -S VASP
 ```
 
-or by checking the list further down this page 
+or by checking [the list further down this page](#description-of-the-different-vasp-builds)
 or by checking the
 [LUMI-EasyBuild-contrib](https://github.com/Lumi-supercomputer/LUMI-EasyBuild-contrib/tree/main/easybuild/easyconfigs/v/VASP)
 repository on GitHub directly.
@@ -71,8 +70,10 @@ There might be several installations of the same VASP version to choose from: `b
 
 * `VASP-5.4.4.pl2.build02-cpeGNU-22.08.eb`. This VASP has patches to read POTCAR files in read-only mode, which lessens the load on the LUMI parallel file systems. In some cases, VASP 5 could stall for 10 minutes at startup just reading input files.
 * `VASP-6.3.2.build02-cpeGNU-22.08.eb`. VASP 6.3.2 with similar I/O patches to behave more nicely towards the parallel file system. We recommend that you use this version, especially if you work with HDF5 files in VASP. Passes the VASP test
+* `VASP-6.3.2-cpeGNU-23.09-VASPsol.eb`. VASP 6.3.2 (with the I/O patch of `build02`), including [VASPsol](https://github.com/henniggroup/VASPsol), an implicit solvation model.
 * `VASP-6.4.1-cpeGNU-22.12-build01.eb`. VASP 6.4.1 release version built without any modifications. Passes the VASP test suite
 * `VASP-6.4.1-cpeGNU-22.12-build02.eb`. VASP 6.4.1 with POTCAR and HDF5 I/O patches. Passes the VASP test suite
+* `VASP-6.4.2-cpeGNU-23.09.eb`. VASP 6.4.2 with POTCAR and HDF5 I/O patches (from `build02`).
 
 ## Example batch scripts
 
@@ -135,9 +136,8 @@ srun vasp_std
   but reducing the number of cores per compute node does not decrease
   performance as much as you might expect. That can be useful when you are
   constrained by memory and need more available memory per MPI rank. It is
-  important to explicitly [pin the MPI ranks to processor
-  cores][slurm-bindings] if you
-  run with less than 128 cores per node.
+  important to explicitly [pin the MPI ranks to processor cores][slurm-bindings] 
+  if you run with less than 128 cores per node.
 * If possible, use k-point parallelization `KPAR` up to the maxium number of
   k-points. It is often a good choice to use 1 compute node per k-point.
 * We generally recommend using VASP version 6 when possible, and not VASP 5 (even though installation scripts are provided). VASP 5 on LUMI exhibits some problems with disk I/O, jobs may appear to hang for several minutes at launch before all input files are read and the calculation begins.

--- a/easybuild/easyconfigs/v/VASP/VASP-6.3.2-cpeGNU-23.09-VASPsol.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.3.2-cpeGNU-23.09-VASPsol.eb
@@ -1,0 +1,49 @@
+# Based on CSCS VASP easyconfig by Luca Marsella
+# Adapted for LUMI by Peter Larsson and Pierre Beaujean
+
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.3.2'
+versionsuffix = '-VASPsol'
+
+homepage = 'http://www.vasp.at'
+description = 'The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles.'
+
+toolchain = { 'name': 'cpeGNU', 'version': '23.09' }
+toolchainopts = {'usempi': True, 'openmp' : True }
+
+sources = ['vasp.6.3.2.tgz']
+patches = [('makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s', '%(builddir)s/vasp.%(version)s'),('POTCAR-readonly.patch')]
+
+dependencies = [
+	('Wannier90','3.1.0'),
+	('DFTD4','3.6.0'),
+    ('libxc','6.2.2','-nofhc'),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+# download & move solvatation.F
+prebuildopts = 'wget https://github.com/henniggroup/VASPsol/raw/29af9be0d43a5539fbaea1925a2ba3f0ca23eac7/src/solvation.F && mv solvation.F src/ && '
+
+# download & modify & apply patch (from https://github.com/henniggroup/VASPsol/issues/64#issuecomment-1099999738)
+prebuildopts += 'wget https://github.com/henniggroup/VASPsol/files/8495230/VASPsol_VASP630.zip && unzip VASPsol_VASP630.zip && '
+prebuildopts += 'sed -i "s/solvation.F/src\\/solvation.F/g" VASPsol_VASP630.patch && '
+prebuildopts += 'sed -i "s/mpi.F/src\\/mpi.F/g" VASPsol_VASP630.patch && '
+prebuildopts += 'sed -i "s/pot.F/src\\/pot.F/g" VASPsol_VASP630.patch && '
+prebuildopts += 'patch -p0 < VASPsol_VASP630.patch && '
+
+# move makefile
+prebuildopts += 'mv makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s makefile.include && unset LIBS && '
+buildopts = "DEPS=1 std gam ncl"
+
+parallel = 4
+
+files_to_copy = [(['bin/vasp_std','bin/vasp_gam','bin/vasp_ncl'],'bin')]
+
+sanity_check_paths = { 'files': ['bin/vasp_std'], 'dirs': [] }
+moduleclass = 'phys'
+
+moduleclass = 'phys'
+

--- a/easybuild/easyconfigs/v/VASP/VASP-6.4.2-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.4.2-cpeGNU-23.09.eb
@@ -1,0 +1,42 @@
+# Based on CSCS VASP easyconfig by Luca Marsella
+# Adapted for LUMI by Peter Larsson, Pierre Beaujean
+# Include optimizations from VASP-6.4.1-cpeGNU-22.12-build02
+
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.4.2'
+
+homepage = 'http://www.vasp.at'
+description = 'The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles.'
+
+toolchain = { 'name': 'cpeGNU', 'version': '23.09' }
+toolchainopts = {'usempi': True, 'openmp' : True }
+
+sources = ['vasp.6.4.2.tgz']
+patches = [('makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s','%(builddir)s/vasp.%(version)s'),('POTCAR-readonly-641.patch')]
+
+# No checksum for makefile.include to simplify editing and recompiling
+checksums = [
+    {'vasp.6.4.2.tgz': 'b704637f7384673f91adfbc803edc5cc7fe736d9623453461f7cdc29b123410e'},
+]
+
+dependencies = [
+	('Wannier90','3.1.0'),
+	('DFTD4','3.6.0'),
+    ('libxc','6.2.2','-nofhc'),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+# Just copy in fully patched makefile.include
+prebuildopts = 'mv makefile.include.%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s makefile.include && unset LIBS && '
+buildopts = "DEPS=1 std gam ncl"
+
+parallel = 4
+
+files_to_copy = [(['bin/vasp_std','bin/vasp_gam','bin/vasp_ncl'],'bin')]
+
+sanity_check_paths = { 'files': ['bin/vasp_std'], 'dirs': [] }
+moduleclass = 'phys'
+

--- a/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.3.2-cpeGNU-23.09-VASPsol
+++ b/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.3.2-cpeGNU-23.09-VASPsol
@@ -1,0 +1,101 @@
+# Default precompiler options
+CPP_OPTIONS = -DHOST=\"LUMI2309\" \
+              -DMPI -DMPI_BLOCK=65536 -Duse_collective \
+              -DscaLAPACK \
+              -DCACHE_SIZE=4000 \
+              -Davoidalloc \
+              -Dvasp6 \
+              -Duse_bse_te \
+              -Dtbdyn \
+              -Dfock_dblbuf \
+              -D_OPENMP -Duse_shmem -DnoSTOPCAR
+
+CPP         = gcc -E -C -w $*$(FUFFIX) >$*$(SUFFIX) $(CPP_OPTIONS)
+
+FC          = ftn -fopenmp
+FCL         = ftn -fopenmp
+
+FREE        = -ffree-form -ffree-line-length-none
+
+FFLAGS      = -w -ffpe-summary=none
+
+OFLAG       = -O3
+OFLAG_IN    = $(OFLAG)
+DEBUG       = -O0
+
+OBJECTS     = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB     = $(CPP)
+FC_LIB      = $(FC)
+CC_LIB      = gcc
+CFLAGS_LIB  = -O
+FFLAGS_LIB  = -O1
+FREE_LIB    = $(FREE)
+
+OBJECTS_LIB = linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS    = g++
+LLIBS       = -lstdc++
+
+##
+## Customize as of this point! Of course you may change the preceding
+## part of this file as well if you like, but it should rarely be
+## necessary ...
+##
+
+# When compiling on the target machine itself, change this to the
+# relevant target when cross-compiling for another architecture
+# march is set by the craype-x86-milan module when compiling for LUMI-C partition
+#FFLAGS     += -march=znver3
+
+# For gcc-10 and higher (comment out for older versions)
+FFLAGS     += -fallow-argument-mismatch
+
+# BLAS and LAPACK (mandatory)
+#OPENBLAS_ROOT ?= /path/to/your/openblas/installation
+BLASPACK    = 
+
+# scaLAPACK (mandatory)
+#SCALAPACK_ROOT ?= /path/to/your/scalapack/installation
+SCALAPACK   = 
+
+LLIBS      += $(SCALAPACK) $(BLASPACK)
+
+# FFTW (mandatory)
+#FFTW_ROOT  ?= /path/to/your/fftw/installation
+# Note the explicit linking to -lffttw3_omp. It needs to be done due a bug in the build system.
+# For some reason, the Cray ftn wrapper does not pick up that OpenMP is enabled for FFTW
+LLIBS      += -L$(FFTW_ROOT)/lib -lfftw3 -lfftw3_omp
+INCS       += -I$(FFTW_INC) $(shell pkg-config --cflags dftd4) 
+
+# HDF5-support (optional but strongly recommended)
+# Use HDF5 from the Cray-module
+CPP_OPTIONS+= -DVASP_HDF5
+#HDF5_ROOT  ?= /path/to/your/hdf5/installation
+LLIBS      += -L$(HDF5_ROOT)/lib -lhdf5_fortran_parallel_gnu
+INCS       += -I$(HDF5_ROOT)/include
+
+# For the VASP-2-Wannier90 interface (optional)
+CPP_OPTIONS    += -DVASP2WANNIER90 -DVASP2WANNIER90v2 
+#WANNIER90_ROOT ?=  
+LLIBS          += -L$(EBROOTWANNIER90)/lib -lwannier -L/$(shell pkg-config --libs dftd4) 
+
+# Add Libxc
+CPP_OPTIONS+= -DUSELIBXC
+LLIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
+INCS      += -I$(EBROOTLIBXC)/include
+
+# For the fftlib library (experimental)
+CPP_OPTIONS+= -Dsysv
+FCL        += fftlib.o
+CXX_FFTLIB  = g++ -fopenmp -std=c++11 -DFFTLIB_THREADSAFE
+INCS_FFTLIB = -I./include -I$(FFTW_ROOT)/include
+LIBS       += fftlib
+LLIBS      += -ldl
+
+# Enable VASPsol
+CPP_OPTIONS+= -Dsol_compat 

--- a/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.4.2-cpeGNU-23.09
+++ b/easybuild/easyconfigs/v/VASP/makefile.include.VASP-6.4.2-cpeGNU-23.09
@@ -1,0 +1,98 @@
+# Default precompiler options
+CPP_OPTIONS = -DHOST=\"LUMI2309\" \
+              -DMPI -DMPI_BLOCK=65536 -Duse_collective \
+              -DscaLAPACK \
+              -DCACHE_SIZE=4000 \
+              -Davoidalloc \
+              -Dvasp6 \
+              -Duse_bse_te \
+              -Dtbdyn \
+              -Dfock_dblbuf \
+              -D_OPENMP -Duse_shmem -DnoSTOPCAR
+
+CPP         = gcc -E -C -w $*$(FUFFIX) >$*$(SUFFIX) $(CPP_OPTIONS)
+
+FC          = ftn -fopenmp
+FCL         = ftn -fopenmp
+
+FREE        = -ffree-form -ffree-line-length-none
+
+FFLAGS      = -w -ffpe-summary=none
+
+OFLAG       = -O3
+OFLAG_IN    = $(OFLAG)
+DEBUG       = -O0
+
+OBJECTS     = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB     = $(CPP)
+FC_LIB      = $(FC)
+CC_LIB      = gcc
+CFLAGS_LIB  = -O
+FFLAGS_LIB  = -O1
+FREE_LIB    = $(FREE)
+
+OBJECTS_LIB = linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS    = g++
+LLIBS       = -lstdc++
+
+##
+## Customize as of this point! Of course you may change the preceding
+## part of this file as well if you like, but it should rarely be
+## necessary ...
+##
+
+# When compiling on the target machine itself, change this to the
+# relevant target when cross-compiling for another architecture
+# march is set by the craype-x86-milan module when compiling for LUMI-C partition
+#FFLAGS     += -march=znver3
+
+# For gcc-10 and higher (comment out for older versions)
+FFLAGS     += -fallow-argument-mismatch
+
+# BLAS and LAPACK (mandatory)
+#OPENBLAS_ROOT ?= /path/to/your/openblas/installation
+BLASPACK    = 
+
+# scaLAPACK (mandatory)
+#SCALAPACK_ROOT ?= /path/to/your/scalapack/installation
+SCALAPACK   = 
+
+LLIBS      += $(SCALAPACK) $(BLASPACK)
+
+# FFTW (mandatory)
+#FFTW_ROOT  ?= /path/to/your/fftw/installation
+# Note the explicit linking to -lffttw3_omp. It needs to be done due a bug in the build system.
+# For some reason, the Cray ftn wrapper does not pick up that OpenMP is enabled for FFTW
+LLIBS      += -L$(FFTW_ROOT)/lib -lfftw3 -lfftw3_omp
+INCS       += -I$(FFTW_INC) $(shell pkg-config --cflags dftd4) 
+
+# HDF5-support (optional but strongly recommended)
+# Use HDF5 from the Cray-module
+CPP_OPTIONS+= -DVASP_HDF5
+#HDF5_ROOT  ?= /path/to/your/hdf5/installation
+LLIBS      += -L$(HDF5_ROOT)/lib -lhdf5_fortran_parallel_gnu
+INCS       += -I$(HDF5_ROOT)/include
+
+# For the VASP-2-Wannier90 interface (optional)
+CPP_OPTIONS    += -DVASP2WANNIER90 -DVASP2WANNIER90v2 
+#WANNIER90_ROOT ?=  
+LLIBS          += -L$(EBROOTWANNIER90)/lib -lwannier -L/$(shell pkg-config --libs dftd4) 
+
+# Add Libxc
+CPP_OPTIONS+= -DUSELIBXC
+LLIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
+INCS      += -I$(EBROOTLIBXC)/include
+
+# For the fftlib library (experimental)
+CPP_OPTIONS+= -Dsysv
+FCL        += fftlib.o
+CXX_FFTLIB  = g++ -fopenmp -std=c++11 -DFFTLIB_THREADSAFE
+INCS_FFTLIB = -I./include -I$(FFTW_ROOT)/include
+LIBS       += fftlib
+LLIBS      += -ldl

--- a/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-23.09.eb
@@ -1,0 +1,62 @@
+# adapted for LUMI by Orian Louant, Pierre Beaujean
+
+easyblock = 'MakeCp'
+
+name = 'Wannier90'
+version = '3.1.0'
+
+homepage = 'http://www.wannier.org'
+
+whatis = [
+    'Description: Wannier90 is a code for generating maximally-localized Wannier functions'
+]
+
+description = """
+Wannier90 is an open-source code (released under GPLv2) for generating
+maximally-localized Wannier functions and using them to compute advanced
+electronic properties of materials with high efficiency and accuracy.
+
+Many electronic structure codes have an interface to Wannier90, including
+Quantum ESPRESSO, Abinit, VASP, Siesta, Wien2k, Fleur, OpenMX and GPAW; and
+there are several post-processing codes that are able to use the output of
+Wannier90 for further analysis and calculation.
+
+In all publications resulting from your use of Wannier90, please cite:
+
+[ref] "Wannier90 as a community code: new features and applications",
+      G. Pizzi et al., J. Phys. Cond. Matt. 32, 165902 (2020)
+
+This module was build with with MPI support.
+"""
+
+docurls = [
+    'User guide and tutorial:  http://www.wannier.org/support/'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True, 'gfortran9-compat': True}
+
+github_account = 'wannier-developers'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+patches = ['Wannier90_3x_ignore_makeinc.patch']
+checksums = [
+    '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254',  # wannier90-3.1.0.tar.gz
+    '561c0d296e0e30b8bb303702cd6e41ded54c153d9b9e6cd9cab73858e5e2945e',  # Wannier90_3x_ignore_makeinc.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True)
+]
+
+buildopts  = 'all F90=$F90 MPIF90=$MPIF90 FCOPTS="$FFLAGS" LDOPTS="$FFLAGS" '
+buildopts += 'COMMS=mpi'
+
+files_to_copy = [(['wannier90.x', 'postw90.x'], 'bin'), (['libwannier.a'], 'lib')]
+
+sanity_check_paths = {
+    'files': ['bin/wannier90.x', 'bin/postw90.x', 'lib/libwannier.a'],
+    'dirs': []
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Add easyconfigs VASP 6.4.2 and 6.3.2 for `LUMI/23.09` (+ updated dependencies), the latter also including the [quasi-official](https://ww-w.vasp.at/info/resource/vaspsol/) extension [VASPsol](https://github.com/henniggroup/VASPsol) to model implicit solvation. 

I ran some test calculations without any issues, but not the entire test suite.