### PR TITLE
Enhanced GDAL module with dependencies for 23.09.

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.5.3-cpeGNU-23.09-cray-python-3.10.10.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.5.3-cpeGNU-23.09-cray-python-3.10.10.eb
@@ -1,0 +1,158 @@
+easyblock = 'ConfigureMake'
+
+local_Blosc_version =        '1.21.5'        # https://github.com/Blosc/c-blosc/releases
+local_cURL_version =         '8.0.1'         # https://curl.haxx.se/download/
+local_expat_version =        '2.5.0'         # https://github.com/libexpat/libexpat/releases
+local_JasPer_version =       '4.0.0'         # https://github.com/jasper-software/jasper/releases
+local_SQLite_version =       '3.42.0'        # https://www.sqlite.org/
+local_libdeflate_version =   '1.18'          # https://github.com/ebiggers/libdeflate/releases
+local_giflib_version =       '5.2.1'         # https://sourceforge.net/projects/giflib/files/
+local_libjpegturbo_version = '2.1.5.1'       # https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+local_libxml2_version =      '2.11.4'        # http://xmlsoft.org/sources/
+local_libpng_version =       '1.6.39'        # http://www.libpng.org/pub/png/libpng.html
+local_libtiff_version =      '4.5.0'         # https://download.osgeo.org/libtiff/
+local_libwebp_version =      '1.3.2'         # https://github.com/webmproject/libwebp/releases
+local_lz4_version =          '1.9.4'         # https://github.com/lz4/lz4/releases
+local_PCRE2_version =        '10.42'         # https://ftp.pcre.org/pub/pcre/
+local_PROJ_version =         '9.2.0'         # https://proj.org/download.html
+local_Xerces_version =       '3.2.5'         # https://xerces.apache.org/xerces-c/releases.html
+local_XZ_version =           '5.4.2'         # https://tukaani.org/xz/
+local_zlib_version =         '1.2.13'        # https://zlib.net/
+local_zstd_version =         '1.5.5'         # https://github.com/facebook/zstd/releases
+
+local_GEOS_version =         '3.12.1'        # https://github.com/libgeos/geos/releases
+local_HDF_version =          '4.2.16-2'      # https://support.hdfgroup.org/ftp/HDF/releases/
+local_libgeotiff_version =   '1.7.1'         # https://github.com/OSGeo/libgeotiff/releases
+
+name =          'GDAL'
+version =       '3.5.3'
+versionsuffix = '-cray-python-3.10.10'
+
+homepage = 'https://www.gdal.org'
+
+whatis = [
+    'Description: translator library for raster geospatial data formats',
+    'This module provides the command line utilities and shared libraries',
+]
+
+description = """
+GDAL is a translator library for raster geospatial data formats that is released
+under an X/MIT style Open Source license by the Open Source Geospatial
+Foundation. As a library, it presents a single abstract data model to the 
+alling application for all supported formats. It also comes with a variety of
+useful commandline utilities for data translation and processing.
+
+This module contains a number of command line tools and shared libraries.
+It is built without support for Python. GDAL does have a lot more features
+than are enabled in this build however. This module was installed through
+EasyBuild, so users experienced with EasyBuild may further extend the
+build recipe to enable additional options in GDAL.
+"""
+
+docurls = [
+   'Web-based documentation on the package home page http://www.gdal.org/',
+]
+
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://download.osgeo.org/gdal/%(version)s/']
+sources =     [SOURCELOWER_TAR_XZ]
+#patches =     ['GDAL-3.0.0_fix-python-CC-CXX.patch']
+checksums = [
+    'd32223ddf145aafbbaec5ccfa5dbc164147fb3348a3413057f9b1600bb5b3890',  # gdal-3.5.3.tar.xz
+#    '223a0ed1afb245527d546bb19e4f80c00f768516ab106d82e53cf36b5a1a2381',  # GDAL-3.0.0_fix-python-CC-CXX.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
+    # Packages from the central software stack
+    ('cURL',          local_cURL_version),
+    ('expat',         local_expat_version),
+    ('PCRE2',         local_PCRE2_version),
+    ('SQLite',        local_SQLite_version),
+    ('libxml2',       local_libxml2_version),
+    ('giflib',        local_giflib_version),
+    ('libpng',        local_libpng_version),
+    ('libjpeg-turbo', local_libjpegturbo_version),
+    ('JasPer',        local_JasPer_version),
+    ('libwebp',       local_libwebp_version),
+    ('LibTIFF',       local_libtiff_version),
+    ('Blosc',         local_Blosc_version),
+    ('lz4',           local_lz4_version),
+    ('libdeflate',    local_libdeflate_version),
+    ('zlib',          local_zlib_version),
+    ('zstd',          local_zstd_version),
+    ('PROJ',          local_PROJ_version),
+    # Packages from the contributed repository
+    ('HDF',           local_HDF_version),
+    ('GEOS',          local_GEOS_version),
+    ('libgeotiff',    local_libgeotiff_version),
+    ('Xerces-C++',    local_Xerces_version),
+]
+
+preconfigopts  = "sed -e 's/-llapack//g' -i.eb configure && "
+preconfigopts += "unset PYTHONPATH && "
+configopts  = '--with-expat=$EBROOTEXPAT '
+configopts += '--with-curl=$EBROOTCURL/bin ' # Path to curl-config
+configopts += '--with-xml2=yes '
+configopts += '--with-xerces=$EBROOTXERCESMINCPLUSPLUS '
+configopts += '--with-pcre2=$EBROOTPCRE2 '
+configopts += '--with-sqlite3=$EBROOTSQLITE '
+# Computational geometry
+configopts += '--with-geos=$EBROOTGEOS/bin/geos-config '
+# File formats
+configopts += '--with-hdf4=$EBROOTHDF '
+configopts += '--with-hdf5=$EBROOTHDF5 '     # Alternative: Use $HDF5_ROOT
+configopts += '--with-netcdf=$EBROOTNETCDF ' # Alternative: Use $NETCDF_DIR
+# Compression libraries
+configopts += '--with-blosc=$EBROOTBLOSC '
+configopts += '--with-libdeflate=$EBROOTLIBDEFLATE '
+configopts += '--with-libz=$EBROOTLIBZ '
+configopts += '--with-lz4=$EBROOTLZ4 '
+configopts += '--with-zstd=$EBROOTZSTD '
+configopts += '--with-liblzma '   # Try with XZ, but the flag only accepts yes and no.
+# Graphics libraries
+configopts += '--with-gif==$EBROOTGIFLIB '
+configopts += '--with-jpeg=$EBROOTLIBJPEGMINTURBO '
+configopts += '--with-png=$EBROOTLIBPNG '
+configopts += '--with-jasper=$EBROOTJASPER '
+configopts += '--with-webp=$EBROOTLIBWEBP '
+configopts += '--with-libtiff=$EBROOTLIBTIFF '
+configopts += '--with-geotiff=$EBROOTLIBGEOTIFF '
+# Python
+configopts += '--with-python=$EBROOTPYTHON/bin/python '
+
+prebuildopts = "unset PYTHONPATH && "
+
+maxparallel = 1
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp LICENSE.TXT PROVENANCE.TXT NEWS.md %(installdir)s/share/licenses/%(name)s',
+]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT, 'lib/pkgconfig/gdal.pc',
+              'share/licenses/GDAL/LICENSE.TXT', 'share/licenses/GDAL/PROVENANCE.TXT'],
+    'dirs':  ['bin', 'include']
+}
+
+sanity_check_commands = [ # Few commands to really test as almost all return error codes when no data file is given.
+    'pkg-config --libs gdal',
+    'gdal-config --version',
+    "python -c 'import osgeo.gdal'",
+]
+
+
+moduleclass = 'data'
+

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.5.3-cpeGNU-23.09-noPython.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.5.3-cpeGNU-23.09-noPython.eb
@@ -1,0 +1,153 @@
+easyblock = 'ConfigureMake'
+
+local_Blosc_version =        '1.21.5'        # https://github.com/Blosc/c-blosc/releases
+local_cURL_version =         '8.0.1'         # https://curl.haxx.se/download/
+local_expat_version =        '2.5.0'         # https://github.com/libexpat/libexpat/releases
+local_JasPer_version =       '4.0.0'         # https://github.com/jasper-software/jasper/releases
+local_SQLite_version =       '3.42.0'        # https://www.sqlite.org/
+local_libdeflate_version =   '1.18'          # https://github.com/ebiggers/libdeflate/releases
+local_giflib_version =       '5.2.1'         # https://sourceforge.net/projects/giflib/files/
+local_libjpegturbo_version = '2.1.5.1'       # https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+local_libxml2_version =      '2.11.4'        # http://xmlsoft.org/sources/
+local_libpng_version =       '1.6.39'        # http://www.libpng.org/pub/png/libpng.html
+local_libtiff_version =      '4.5.0'         # https://download.osgeo.org/libtiff/
+local_libwebp_version =      '1.3.2'         # https://github.com/webmproject/libwebp/releases
+local_lz4_version =          '1.9.4'         # https://github.com/lz4/lz4/releases
+local_PCRE2_version =        '10.42'         # https://ftp.pcre.org/pub/pcre/
+local_PROJ_version =         '9.2.0'         # https://proj.org/download.html
+local_Xerces_version =       '3.2.5'         # https://xerces.apache.org/xerces-c/releases.html
+local_XZ_version =           '5.4.2'         # https://tukaani.org/xz/
+local_zlib_version =         '1.2.13'        # https://zlib.net/
+local_zstd_version =         '1.5.5'         # https://github.com/facebook/zstd/releases
+
+local_GEOS_version =         '3.12.1'        # https://github.com/libgeos/geos/releases
+local_HDF_version =          '4.2.16-2'      # https://support.hdfgroup.org/ftp/HDF/releases/
+local_libgeotiff_version =   '1.7.1'         # https://github.com/OSGeo/libgeotiff/releases
+
+name =          'GDAL'
+version =       '3.5.3'
+versionsuffix = '-noPython'
+
+homepage = 'https://www.gdal.org'
+
+whatis = [
+    'Description: translator library for raster geospatial data formats',
+    'This module provides the command line utilities and shared libraries',
+]
+
+description = """
+GDAL is a translator library for raster geospatial data formats that is released
+under an X/MIT style Open Source license by the Open Source Geospatial
+Foundation. As a library, it presents a single abstract data model to the 
+alling application for all supported formats. It also comes with a variety of
+useful commandline utilities for data translation and processing.
+
+This module contains a number of command line tools and shared libraries.
+It is built without support for Python. GDAL does have a lot more features
+than are enabled in this build however. This module was installed through
+EasyBuild, so users experienced with EasyBuild may further extend the
+build recipe to enable additional options in GDAL.
+"""
+
+docurls = [
+   'Web-based documentation on the package home page http://www.gdal.org/',
+]
+
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://download.osgeo.org/gdal/%(version)s/']
+sources =     [SOURCELOWER_TAR_XZ]
+#patches =     ['GDAL-3.0.0_fix-python-CC-CXX.patch']
+checksums = [
+    'd32223ddf145aafbbaec5ccfa5dbc164147fb3348a3413057f9b1600bb5b3890',  # gdal-3.5.3.tar.xz
+#    '223a0ed1afb245527d546bb19e4f80c00f768516ab106d82e53cf36b5a1a2381',  # GDAL-3.0.0_fix-python-CC-CXX.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+#    ('cray-python', EXTERNAL_MODULE),
+    # Packages from the central software stack
+    ('cURL',          local_cURL_version),
+    ('expat',         local_expat_version),
+    ('PCRE2',         local_PCRE2_version),
+    ('SQLite',        local_SQLite_version),
+    ('libxml2',       local_libxml2_version),
+    ('giflib',        local_giflib_version),
+    ('libpng',        local_libpng_version),
+    ('libjpeg-turbo', local_libjpegturbo_version),
+    ('JasPer',        local_JasPer_version),
+    ('libwebp',       local_libwebp_version),
+    ('LibTIFF',       local_libtiff_version),
+    ('Blosc',         local_Blosc_version),
+    ('lz4',           local_lz4_version),
+    ('libdeflate',    local_libdeflate_version),
+    ('zlib',          local_zlib_version),
+    ('zstd',          local_zstd_version),
+    ('PROJ',          local_PROJ_version),
+    # Packages from the contributed repository
+    ('HDF',           local_HDF_version),
+    ('GEOS',          local_GEOS_version),
+    ('libgeotiff',    local_libgeotiff_version),
+    ('Xerces-C++',    local_Xerces_version),
+]
+
+preconfigopts = "sed -e 's/-llapack//g' -i.eb configure && "
+configopts  = '--with-expat=$EBROOTEXPAT '
+configopts += '--with-curl=$EBROOTCURL/bin ' # Path to curl-config
+configopts += '--with-xml2=yes '
+configopts += '--with-xerces=$EBROOTXERCESMINCPLUSPLUS '
+configopts += '--with-pcre2=$EBROOTPCRE2 '
+configopts += '--with-sqlite3=$EBROOTSQLITE '
+# Computational geometry
+configopts += '--with-geos=$EBROOTGEOS/bin/geos-config '
+# File formats
+configopts += '--with-hdf4=$EBROOTHDF '
+configopts += '--with-hdf5=$EBROOTHDF5 '     # Alternative: Use $HDF5_ROOT
+configopts += '--with-netcdf=$EBROOTNETCDF ' # Alternative: Use $NETCDF_DIR
+# Compression libraries
+configopts += '--with-blosc=$EBROOTBLOSC '
+configopts += '--with-libdeflate=$EBROOTLIBDEFLATE '
+configopts += '--with-libz=$EBROOTLIBZ '
+configopts += '--with-lz4=$EBROOTLZ4 '
+configopts += '--with-zstd=$EBROOTZSTD '
+configopts += '--with-liblzma '   # Try with XZ, but the flag only accepts yes and no.
+# Graphics libraries
+configopts += '--with-gif==$EBROOTGIFLIB '
+configopts += '--with-jpeg=$EBROOTLIBJPEGMINTURBO '
+configopts += '--with-png=$EBROOTLIBPNG '
+configopts += '--with-jasper=$EBROOTJASPER '
+configopts += '--with-webp=$EBROOTLIBWEBP '
+configopts += '--with-libtiff=$EBROOTLIBTIFF '
+configopts += '--with-geotiff=$EBROOTLIBGEOTIFF '
+# Python
+configopts += '--without-python '
+
+maxparallel = 1
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp LICENSE.TXT PROVENANCE.TXT NEWS.md %(installdir)s/share/licenses/%(name)s',
+]
+
+#modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.a', 'lib/libgdal.%s' % SHLIB_EXT, 'lib/pkgconfig/gdal.pc',
+              'share/licenses/GDAL/LICENSE.TXT', 'share/licenses/GDAL/PROVENANCE.TXT'],
+    'dirs':  ['bin', 'include']
+}
+
+sanity_check_commands = [ # Few commands to really test as almost all return error codes when no data file is given.
+    'pkg-config --libs gdal',
+    'gdal-config --version',     
+]
+
+moduleclass = 'data'
+

--- a/easybuild/easyconfigs/g/GDAL/README.md
+++ b/easybuild/easyconfigs/g/GDAL/README.md
@@ -19,7 +19,7 @@ to sometimes fail so the build process has to be entirely sequential and can tak
 -   [GDAL support in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/g/GDAL)
     
     
-### GDAL 3.5.2 for cpeGNU 3.5.2
+### GDAL 3.5.2 for cpeGNU 22.08
 
 -   The EasyConfig file is derived from the EasyBuilders recipes, and with some
     adaptations copied from the CSCS EasyConfigs.
@@ -31,3 +31,11 @@ to sometimes fail so the build process has to be entirely sequential and can tak
 -   GDAL has way more optional features than are enabled in this EasyConfig, so feel free
     to further extend.
 
+
+### GDAL 3.5.3 for cpeGNU 23.09
+
+-   3.5 is the last version of GDAL that can be built using autoconf, and this is the
+    most recent bugfix release as of now.
+    
+-   The EasyConfig is a trivial port of the 3.5.2 one, with the usual version updates 
+    and aligning the structure a bit more to other recent LUMI easyconfigs.

--- a/easybuild/easyconfigs/g/GDAL/USER.md
+++ b/easybuild/easyconfigs/g/GDAL/USER.md
@@ -1,0 +1,28 @@
+# GDAL User Instructions
+
+## What is GDAL?
+
+GDAL is a translator library for raster geospatial data formats that is released
+under an X/MIT style Open Source license by the Open Source Geospatial
+Foundation. As a library, it presents a single abstract data model to the 
+alling application for all supported formats. It also comes with a variety of
+useful commandline utilities for data translation and processing.
+
+
+## Installing
+
+The GDAL 3.5.x versions all use a similar installation process. 
+GDAL has an enormous amount of optional features, each requiring additional
+dependencies. The GDAL modules built by the available EasyConfigs are far
+from feature-complete (and several features would in fact not even make
+sense on LUMI). However, in version 3.5.3 (from LUMI/23.09 on) we did
+enable some additional features.
+
+The build process of GDAL is not completely stable and for that reason we
+cannot use a parallel build process. As a result, building GDAL 3.5.x is
+extremely slow and can easily take 2 hours or more.
+
+From GDAL 3.6 on, a different build process was imposed and the older build
+process is no longer supported. Unfortunately this new build process comes with
+several so far unsolved problems on LUMI so we cannot currently offer newer
+versions of GDAL.

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.12.1-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.12.1-cpeGNU-23.09.eb
@@ -1,0 +1,58 @@
+easyblock = 'CMakeMake'
+
+local_GEOS_version =         '3.12.1'        # https://github.com/libgeos/geos/releases
+
+name =    'GEOS'
+version = local_GEOS_version
+
+homepage = 'https://trac.osgeo.org/geos'
+
+whatis = [
+    'Description: GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS)'
+]
+
+description = """
+GEOS (Geometry Engine - Open Source) is a C++ port of the  Java Topology Suite
+(JTS). As such, it aims to contain the complete functionality of JTS in C++.
+This includes all the OpenGIS Simple Features for SQL spatial predicate
+functions and spatial operators, as well as specific JTS enhanced topology
+functions.
+
+GEOS is available under the terms of GNU Lesser General Public License (LGPL),
+and is a project of OSGeo.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+source_urls = ['https://download.osgeo.org/geos/']
+sources =     [SOURCELOWER_TAR_BZ2]
+checksums =   ['d6ea7e492224b51193e8244fe3ec17c4d44d0777f3c32ca4fb171140549a0d03']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+# Build static and shared libraries
+configopts = [
+    '-DCMAKE_INSTALL_LIBDIR=lib', 
+    '-DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib'
+]
+
+postinstallcmds = [
+    'pwd',
+    'cd ../%(namelower)s-%(version)s && mkdir -p %(installdir)s/share/licenses/GEOS && cp -f COPYING %(installdir)s/share/licenses/GEOS/COPYING',
+]
+
+sanity_check_paths = {
+    'files': ['bin/geos-config', 'bin/geosop', 'lib/libgeos.%s' % SHLIB_EXT, 'lib/libgeos.a', 'include/geos_c.h',
+              'share/licenses/GEOS/COPYING'],
+    'dirs':  [],
+}
+
+sanity_check_commands = [
+    'pkg-config --libs geos',
+    'geos-config --cflags',
+    'geosop --help',
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GEOS/README.md
+++ b/easybuild/easyconfigs/g/GEOS/README.md
@@ -23,3 +23,7 @@
     to transform this EasyConfig into a bundle component where it is important that all
     components use the same directory.
 
+
+### Version 3.12.1 for cpeGNU 23.09
+
+-   The EasyConfig is a trivial version update of the 23.09 one.

--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.16-2-cpeGNU-23.09.eb
@@ -1,0 +1,85 @@
+easyblock = 'ConfigureMake'
+
+local_HDF_version =          '4.2.16-2'      # https://support.hdfgroup.org/ftp/HDF/releases/
+
+local_libjpegturbo_version = '2.1.5.1'       # https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+local_Szip_version =         '2.1.1'         # https://support.hdfgroup.org/ftp/lib-external/szip/
+local_libtirpc_version =     '1.3.3'         # https://sourceforge.net/projects/libtirpc/files/libtirpc/
+local_zlib_version =         '1.2.13'        # https://zlib.net/
+
+name =    'HDF'
+version = local_HDF_version
+
+homepage = 'https://www.hdfgroup.org/products/hdf4/'
+
+whatis = [
+    'Description: HDF provides the HDF4 libraries'
+]
+
+description = """
+HDF (also known as HDF4) is a library and multi-object file format for
+storing and managing data between machines.
+
+This library has been superseded by HDF5. One should not develop new
+code using the HDF4 libraries as they are no longer well supported and
+not further developed.
+
+For compatibility with GDAL this library has been compiled without netcdf
+and Fortran support in the shared library version.
+"""
+
+docurls = [
+    'Man pages: overview man page hdf and man pages for ncdump and ncgen'    
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src/']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = [
+    'c5c3234b5012258aef2e4432f649b31c21b26015afba1857ad83640c3f2b692c',  # hdf-4.2.16-2.tar.bz2
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('libjpeg-turbo', local_libjpegturbo_version),
+    ('Szip',          local_Szip_version),
+    ('zlib',          local_zlib_version),
+    ('libtirpc',      local_libtirpc_version),
+]
+
+preconfigopts = "LIBS='-ltirpc' "
+local_common_configopts  = '--with-szlib=$EBROOTSZIP CFLAGS="$CFLAGS -I$EBROOTLIBTIRPC/include/tirpc" '
+local_common_configopts += '--includedir=%(installdir)s/include/%(namelower)s '
+configopts = [
+    # -fallow-argument-mismatch is required to compile with GCC 10.x
+    local_common_configopts + 'FFLAGS="$FFLAGS -fallow-argument-mismatch"',
+    # Cannot build shared libraries and Fortran...
+    # https://trac.osgeo.org/gdal/wiki/HDF#IncompatibilitywithNetCDFLibraries
+    # netcdf must be disabled to allow HDF to be used by GDAL
+    local_common_configopts + "--enable-shared --disable-fortran --disable-netcdf",
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/HDF && cp -f COPYING %(installdir)s/share/licenses/HDF/COPYING',
+]
+
+modextrapaths = {'CPATH': 'include/hdf'}
+
+sanity_check_paths = {
+    'files': ['bin/h4cc', 'bin/ncdump', 'lib/libdf.a', 'lib/libhdf4.settings', 'lib/libmfhdf.a',
+              'lib/libmfhdf.%s' % SHLIB_EXT, 'share/licenses/HDF/COPYING'],
+    'dirs':  ['include/hdf'],
+}
+
+sanity_check_commands = [
+    "h4cc --help",
+    "ncdump -V",
+]
+
+moduleclass = 'data'
+

--- a/easybuild/easyconfigs/h/HDF/README.md
+++ b/easybuild/easyconfigs/h/HDF/README.md
@@ -19,3 +19,8 @@ using it.
 
 -   The EasyConfig is a mix of the CSCS and EasyBuilder ones.
 
+
+### Version 4.2.16-2 for cpeGNU 23.09 and later
+
+-   Trivial port of the EasyConfig for 4.2.15
+

--- a/easybuild/easyconfigs/l/libgeotiff/README.md
+++ b/easybuild/easyconfigs/l/libgeotiff/README.md
@@ -16,6 +16,6 @@
 -   [libgeotiff in the CSCS repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/l/libgeotiff)
     
     
-### Version 1.7.1 for cpeGNU/22.08
+### Version 1.7.1 for cpeGNU/22.08 and cpeGNU/23.09
 
 -   The EasyConfig is derived from the EasyBuilders one.

--- a/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.7.1-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/l/libgeotiff/libgeotiff-1.7.1-cpeGNU-23.09.eb
@@ -1,0 +1,62 @@
+easyblock = 'ConfigureMake'
+
+local_libgeotiff_version =   '1.7.1'         # https://github.com/OSGeo/libgeotiff/releases
+
+local_cURL_version =         '8.0.1'         # https://curl.haxx.se/download/
+local_PROJ_version =         '9.2.0'         # https://proj.org/download.html
+local_SQLite_version =       '3.42.0'        # https://www.sqlite.org/
+local_libjpegturbo_version = '2.1.5.1'       # https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+local_libtiff_version =      '4.5.0'         # https://download.osgeo.org/libtiff/
+local_zlib_version =         '1.2.13'        # https://zlib.net/
+
+name =    'libgeotiff'
+version = local_libgeotiff_version
+
+homepage = 'https://directory.fsf.org/wiki/Libgeotiff'
+
+whatis = [
+    'Description: libgeotiff is a library for reading and writing coordinate system information from/to GeoTIFF files'    
+]
+
+description = """
+'libgeotiff' is a library (normally built on top of libtiff) for reading and 
+writing coordinate system information from/to GeoTIFF files. It includes CSV 
+files for expanding projected coordinate system codes into full projections, 
+and definitions and examples of transforming the definitions into a form that 
+can be used with the PROJ.4 projections library. It also includes the sample 
+applications listgeo (for dumping GeoTIFF information in readable form) and 
+geotifcp (for applying geotiff tags to an existing TIFF or GeoTIFF file).
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+source_urls = ['https://download.osgeo.org/geotiff/libgeotiff']
+sources = [SOURCE_TAR_GZ]
+checksums = ['05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('PROJ',          local_PROJ_version),
+    ('libjpeg-turbo', local_libjpegturbo_version),
+    ('zlib',          local_zlib_version),
+    ('SQLite',        local_SQLite_version),
+    ('LibTIFF',       local_libtiff_version),
+    ('cURL',          local_cURL_version),
+]
+
+configopts  = '--with-libtiff=$EBROOTLIBTIFF --with-proj=$EBROOTPROJ --with-zlib=$EBROOTZLIB '
+configopts += '--with-jpeg=$EBROOTLIBJPEGMINTURBO '
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/libgeotiff && cp -f LICENSE %(installdir)s/share/licenses/libgeotiff/LICENSE',
+]
+
+sanity_check_paths = {
+    'files': ['bin/listgeo', 'lib/libgeotiff.a', 'lib/libgeotiff.%s' % SHLIB_EXT, 'share/licenses/libgeotiff/LICENSE'],
+    'dirs':  ['include', 'share/man/man1'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/versions-contrib-23.09.txt
+++ b/easybuild/easyconfigs/versions-contrib-23.09.txt
@@ -11,8 +11,12 @@ local_CDO_version =          '2.3.0'         # https://code.mpimet.mpg.de/projec
 local_CMOR_version =         '3.7.3'         # https://github.com/PCMDI/cmor/releases
 local_CppUnit =              '1.15.1'        # https://dev-www.libreoffice.org/src/
 
-local_ecCodes_version =      '2.32.0'        # https://confluence.ecmwf.int/display/ECC/Releases
+local_ecCodes_version =      '2.12.0'        # https://confluence.ecmwf.int/display/ECC/Releases
 
+local_GDAL_version =         '3.8.2'         # https://github.com/OSGeo/gdal/releases
+local_GEOS_version =         '3.12.1'        # https://github.com/libgeos/geos/releases
+
+local_HDF_version =          '4.2.16-2'      # https://support.hdfgroup.org/ftp/HDF/releases/
 local_HTSlib_version =       '1.18'          # https://github.com/samtools/htslib/releases
 
 local_jsonc_version =        '0.16'          # https://github.com/json-c/json-c/tags
@@ -20,6 +24,7 @@ local_jsonc_version =        '0.16'          # https://github.com/json-c/json-c/
 local_libaio_version =       '0.3.113'       # https://pagure.io/libaio/releases
 local_libaio_libversion =    '1.0.2'         # Version for the .so file.
 local_libdap_version =       '3.20.11'       # https://www.opendap.org/pub/source/
+local_libgeotiff_version =   '1.7.1'         # https://github.com/OSGeo/libgeotiff/releases
 local_libsodium_version =    '1.0.19'        # https://download.libsodium.org/libsodium/releases/
 
 local_NCO_version =          '5.1.8'         # https://github.com/nco/nco/releases
@@ -35,6 +40,8 @@ local_SAMtools_version =     '1.18'          # https://github.com/samtools/samto
 local_SZ_version =           '2.1.12.5'      # https://github.com/szcompressor/SZ/releases
 
 local_VCFtools_version =     '0.1.16'        # https://github.com/vcftools/vcftools/releases
+
+local_Xerces_version =       '3.2.5'         # https://xerces.apache.org/xerces-c/releases.html
 
 local_ZeroMQ_version =       '4.3.5'         # https://github.com/zeromq/libzmq/releases/
 local_zfp_version =          '1.0.0'         # https://github.com/LLNL/zfp/releases

--- a/easybuild/easyconfigs/x/Xerces-C++/LICENSE.md
+++ b/easybuild/easyconfigs/x/Xerces-C++/LICENSE.md
@@ -1,0 +1,8 @@
+# Xerces-C++ license
+
+Xerces-C++ is licensed under the
+[Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+After installation and loading of the module, a copy of the license is also available 
+in the
+`$EBROOTXERCESMINCPLUSPLUS/share/licenses/Xerces-C++` subdirectory.

--- a/easybuild/easyconfigs/x/Xerces-C++/README.md
+++ b/easybuild/easyconfigs/x/Xerces-C++/README.md
@@ -1,0 +1,23 @@
+# Xerces-C++ technical information
+
+-   [Xerces-C++ home page](https://xerces.apache.org/xerces-c/)
+
+    -   [Release info](https://xerces.apache.org/xerces-c/releases.html)
+
+
+## EasyBuild
+
+-   [Support for Xerces-C++ in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/x/Xerces-C%2B%2B)
+
+-   [Support for Xerces-C++ in the CSCS repository](https://github.com/eth-cscs/production/tree/master/easybuild/easyconfigs/x/xerces-c)
+
+-   [Support for Xerces-C++ in Spack: package xerces-c](https://packages.spack.io/package.html?name=xerces-c)
+
+
+### Version 3.2.5 for 23.09
+
+-   The EasyConfig is derived from the one in the EasyBuilders repository.
+
+-   Checked to also run some commands to test if they load OK, but as the
+    commands don't have a flag to request the version and as `-h`
+    also returns an error code, there is no easy way to check them.

--- a/easybuild/easyconfigs/x/Xerces-C++/USER.md
+++ b/easybuild/easyconfigs/x/Xerces-C++/USER.md
@@ -1,0 +1,10 @@
+# Xerces-C++ User Information
+
+## What is Xercer-C++?
+
+Xerces-C++ is a validating XML parser written in a portable
+subset of C++. Xerces-C++ makes it easy to give your application the ability to
+read and write XML data. A shared library is provided for parsing, generating,
+manipulating, and validating XML documents using the DOM, SAX, and SAX2
+APIs.
+

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.2.5-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.2.5-cpeGNU-23.09.eb
@@ -1,0 +1,56 @@
+easyblock = 'CMakeMake'
+
+local_cURL_version =         '8.0.1'         # https://curl.haxx.se/download/
+
+local_Xerces_version =       '3.2.5'         # https://xerces.apache.org/xerces-c/releases.html
+
+name =    'Xerces-C++'
+version = local_Xerces_version
+
+homepage = 'https://xerces.apache.org/xerces-c/'
+
+whatis = [
+    'Description: Xerces-C++ is a validating XML parser written in a portable subset of C++.'    
+]
+
+description = """
+Xerces-C++ is a validating XML parser written in a portable
+subset of C++. Xerces-C++ makes it easy to give your application the ability to
+read and write XML data. A shared library is provided for parsing, generating,
+manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+source_urls = ['https://archive.apache.org/dist/xerces/c/%(version_major)s/sources/']
+sources =     ['xerces-c-%(version)s.tar.gz']
+checksums =   ['545cfcce6c4e755207bd1f27e319241e50e37c0c27250f11cda116018f1ef0f5']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True), # For CMake
+]
+
+dependencies = [
+    ('cURL', local_cURL_version),
+]
+
+configopts = '-DCMAKE_INSTALL_LIBDIR=lib '
+
+runtest = 'test'
+
+postinstallcmds = [
+    'cd ../xerces-c-%(version)s && mkdir -p %(installdir)s/share/licenses/%(name)s && cp LICENSE NOTICE CREDITS README %(installdir)s/share/licenses/%(name)s',
+]
+
+sanity_check_paths = {
+    'files': ['bin/XInclude',
+              'include/xercesc/xinclude/XIncludeUtils.hpp',
+              'lib/libxerces-c-3.2.%s' % SHLIB_EXT],
+    'dirs':  ['bin', 'include', 'lib']
+}
+
+# Note that there are several commands in the bin subdirectory, but none of them
+# has a good test option. --version is not known and -h returns help but also an
+# error return code.
+
+moduleclass = 'lib'


### PR DESCRIPTION
We stuck to version 3.5.3 as this is the last version that builds with autotools. So far we failed to build newer versions with the CMake build process.