### PR TITLE
Update HyperQueue and its build dependency Rust for 23.09

### DIFF
--- a/easybuild/easyconfigs/h/HyperQueue/HyperQueue-0.17.0.eb
+++ b/easybuild/easyconfigs/h/HyperQueue/HyperQueue-0.17.0.eb
@@ -1,0 +1,88 @@
+# We suggest to install this build recipe in partition/common so that
+# the same binaries are available for all LUMI partitions. This will make
+# it a lot easier to start HyperQueue. This version was tested in the
+# LUMI/23.09 environment.
+#
+# HyperQueue is written in Rust and build using the Rust cargo system.
+# As there is no support in EasyBuild for building with cargo and as we
+# want to avoid building a special-purpose EasyBlock for HyperQueue in this
+# stage of development of the tool, we take another route: We use the CmdCp
+# generic EasyBlock to execute the cargo build command in the build phase and
+# then copy the executable manually in the install phase.
+#
+# Note that this build may not be reproducible: Cargo pulls in a lot of dependencies
+# so those sources are not saved by EasyBuild, and if the sources disappear from the
+# location where they are found or are modified, rebuilding will fail or produce a
+# different result.
+#
+easyblock = 'CmdCp'
+
+# These dependency version numbers are correct for the LUMI/21.08 software stack.
+local_Rust_version  =      '1.75.0'   # https://www.rust-lang.org/
+local_HyperQueue_version = '0.17.0'   # https://github.com/It4innovations/hyperqueue/releases
+
+name =    'HyperQueue'
+version = local_HyperQueue_version
+
+homepage = 'https://it4innovations.github.io/hyperqueue/'
+
+whatis = [
+    'Description: HyperQueue (HQ) lets you build a computation plan consisting of a large amount of tasks and then execute it transparently over a system like SLURM/PBS'
+]
+
+description = """
+HyperQueue lets you build a computation plan consisting of a large amount of
+tasks and then execute it transparently over a system like SLURM/PBS. It
+dynamically groups jobs into SLURM/PBS jobs and distributes them to fully
+utilize allocated notes. You thus do not have to manually aggregate your
+tasks into SLURM/PBS jobs.
+
+Note that there is a breaking change in version 0.17.0: the automatically
+detected resource "mem" (RAM size of a worker) is now in megabytes, e.e.,
+`--resource mem=100` now asks for 100 MiB instead of 100 bytes.
+
+Also see the "CHANGELOG.md" file in $EBROOTHYPERQUEUE/share/licenses/HyperQueue
+after loading the module.
+"""
+
+docurls = [
+    'Web-based manual at https://it4innovations.github.io/hyperqueue/'
+]
+
+toolchain = SYSTEM
+
+# https://github.com/It4innovations/hyperqueue/archive/refs/tags/v0.4.0.tar.gz
+sources = {
+    'download_filename': 'v%(version)s.tar.gz',
+    'filename':          SOURCELOWER_TAR_GZ,
+    'source_urls':       ['https://github.com/It4innovations/hyperqueue/archive/refs/tags']
+}
+checksums = [
+    {'hyperqueue-0.17.0.tar.gz': '61bd572f76800205e44bb955eb3b1b583f0ffdf1a3852f39665063c0330047f6'},
+]
+
+builddependencies = [
+    ('Rust',       local_Rust_version),
+]
+
+local_module_conf = f'module unload cce gcc aocc amd PrgEnv-gnu PrgEnv-cray PrgEnv-aocc PrgEnv-amd craype perftools-base ; module list ; '
+
+cmds_map = [
+    ('.*', local_module_conf + 'mkdir -p %(builddir)s/cargo ; CARGO_HOME="%(builddir)s/cargo" RUSTFLAGS="-C target-cpu=znver2" cargo build --release')
+]
+
+files_to_copy = [
+    (['target/release/hq'], 'bin'),
+    (['LICENSE', 'CHANGELOG.md'], 'share/licenses/%(name)s'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/hq'],
+    'dirs':  [],
+}
+
+sanity_check_commands = [
+    "hq -V",
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HyperQueue/LICENSE.md
+++ b/easybuild/easyconfigs/h/HyperQueue/LICENSE.md
@@ -4,3 +4,6 @@ HyperQueue is licensed under the MIT License.
 See the
 [LICENSE file in the GitHub repositorty](https://github.com/It4innovations/hyperqueue/blob/main/LICENSE).
 
+From version 0.17.0 on, the LICENSE file is also available in
+`$EBROOTHYPERQUEUE/share/licenses/HyperQueue`
+after installation of the package and loading of the module.

--- a/easybuild/easyconfigs/h/HyperQueue/README.md
+++ b/easybuild/easyconfigs/h/HyperQueue/README.md
@@ -5,6 +5,8 @@
   * [HyperQueue GitHub](https://github.com/It4innovations/hyperqueue)
 
       * [GitHub releases](https://github.com/It4innovations/hyperqueue/releases)
+      
+      *  Check the [change log on GitHub](https://github.com/It4innovations/hyperqueue/blob/main/CHANGELOG.md)
 
   * [Guide for Cargo, the package manager used to install HyperQueue](https://doc.rust-lang.org/cargo/guide/)
 
@@ -79,4 +81,10 @@ We build our own EasyConfig. Two big warnings are needed though:
   * Trivial modification of the 0.5.0 one, but we do take extra care to avoid picking up 
     toolchain components.
 
+
+### 0.17.0 for use with Rust/1.75.0
+
+  * Trivial modification of the 0.16.0. However, we now also copy the LICENSE and CHANGELOG.md
+    files to the software installation and took care to warn for a breaking change in the help
+    information of the module.
 

--- a/easybuild/easyconfigs/h/HyperQueue/USER.md
+++ b/easybuild/easyconfigs/h/HyperQueue/USER.md
@@ -1,0 +1,55 @@
+# HyperQueue user information
+
+[HyperQueue](https://it4innovations.github.io/hyperqueue/)
+is software developed at LUMI-partner [IT4Innovations](https://www.it4i.cz/en).
+
+It is a tool designed to simplify execution of large workflows on HPC clusters. 
+It allows you to execute a large number of tasks in a simple way, without having 
+to manually submit jobs into batch schedulers like PBS or Slurm. You just specify 
+what you want to compute – HyperQueue will automatically ask for computational 
+resources and dynamically load-balance tasks across all allocated nodes and cores.
+Hence it is one of the tools that can be used to work around the strict limits for
+the number of jobs for the Slurm scheduler on LUMI.
+
+Besides the [user documentation](https://it4innovations.github.io/hyperqueue/)
+you may also want to have a look at the 
+[change log of the code](https://github.com/It4innovations/hyperqueue/blob/main/CHANGELOG.md)
+as breaking changes do occur from time to time.
+
+
+## Installation
+
+HyperQueue requires Rust as a dependency. Hence each version has a preferred
+version of the LUMI software stack. However, from HyperQueue 0.17.0 on, we try 
+to build our Rust build recipes so that they can also be installed in other
+than the intended versions of the LUMI stack, using a different version of the
+buildtools that are needed to compile Rust. We have not tested those combinations
+though.
+
+As HyperQueue doesn't really benefit from processor-specific optimisations (and
+Rust as a compiler isn't run frequently so doesn't really need it either) we
+suggest the following slightly non-standard procedures to install HyperQueue:
+To install in a LUMI software stack, use `partition/common`, and afterwards
+HyperQueue will be available in all main partitions of the software stack with
+just a single install.
+
+E.g.,
+HyperQueue 0.17.0 was tested specifically in LUMI/23.09 (as can be seen
+if you open the EasyConfig via the links on this page). So one can install
+it as follows:
+
+``` bash
+module load LUMI/23.09 partition/common
+module load EasyBuild-user
+eb HyperQueue-0.17.0.eb -r
+```
+
+This will also install the required version of the Rust compiler first which
+is actually a rather time-consuming thing, so don't be surprised if the build
+takes one hour.
+
+After a successful installation, Rust and HyperQueue will be available in 
+all partitions of the LUMI/23.09 stack. 
+
+Installation of HyperQueue 0.17.0 or later may work in other versions of the
+LUMI stack also but this has not been tested neither do we support it.

--- a/easybuild/easyconfigs/r/Rust/README.md
+++ b/easybuild/easyconfigs/r/Rust/README.md
@@ -45,3 +45,11 @@
     that we appeared to have with the 1.60.0 version.
     
   * Checked with what the EasyBlock for Rust in an upcoming version of EasyBuild does.
+
+  
+### Rust 1.75.0, developed for LUMI/23.09
+
+  * A port of the 1.70.0 EasyConfig, but now using gcc/12.2.0.
+  
+  * Adapted the code a little bit so that in principle it could also work in other 
+    versions of the LUMI stack than the intended one.

--- a/easybuild/easyconfigs/r/Rust/Rust-1.75.0.eb
+++ b/easybuild/easyconfigs/r/Rust/Rust-1.75.0.eb
@@ -1,0 +1,105 @@
+# This version of the Rust EasyConfig was developed with buildtools/23.09
+# so should be installed in LUMI/23.09. It may work in other versions of 
+# the LUMI stacks also.
+#
+# Rust doesn't seem to like the old gcc compiler on the system.
+# I wonder if some problems are due to a too old linker or so.
+easyblock = "ConfigureMake"
+
+name =    'Rust'
+version = '1.75.0'
+
+local_LUMI_version = '23.09'
+local_gcc_version =  '12.2.0'
+
+import os 
+local_LUMI_version = os.getenv( "LUMI_STACK_VERSION" )
+if local_LUMI_version == None :
+    local_LUMI_version = '23.09'
+
+homepage = 'https://www.rust-lang.org'
+
+whatis = [
+    "Description: Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety"
+]
+
+description = """
+Rust is blazingly fast and memory-efficient: with no runtime or garbage collector,
+it can power performance-critical services, run on embedded devices, and easily
+integrate with other languages. Rust’s rich type system and ownership model
+guarantee memory-safety and thread-safety — enabling you to eliminate many
+classes of bugs at compile-time.
+"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://static.rust-lang.org/dist/']
+sources =     ['rustc-%(version)s-src.tar.gz']
+patches =     ['Rust-1.75_sysroot-fix-interpreter.patch']
+checksums = [
+    {'rustc-1.75.0-src.tar.gz':                 '5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088'},
+    {'Rust-1.75_sysroot-fix-interpreter.patch': '220129db55e022a98d25028da5dcc9f26b252dd995c3ac92f6312dbb1e362cb1'},
+]
+
+builddependencies = [
+    ('buildtools', local_LUMI_version),
+]
+
+dependencies = [
+#    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+osdependencies = [
+    ('openssl-devel', 'libssl-dev', 'libopenssl-devel'), # For CMake
+]
+
+#
+# Configure phase
+#
+
+local_module_conf = f'module unload cce gcc aocc amd PrgEnv-gnu PrgEnv-cray PrgEnv-aocc PrgEnv-amd craype perftools-base ; module load gcc/{local_gcc_version} ; module list ; '
+
+# TODO: Double-check if it makes sense to set CFLAGS, figure out how to see the compiler flags
+# in the log file which may not be trivial as we do not directly call Make.
+preconfigopts  = local_module_conf
+#preconfigopts += 'CFLAGS="-macrch=znver1 -O2 -fpic" CXXFLAGS="-march=znver1 -O2 -fpic" '
+
+configopts  = '--enable-extended '                # Used in the new EasyBlock for EasyBuild 4.8
+configopts += '--sysconfdir=%(installdir)s/etc '  # Used in the new EasyBlock for EasyBuild 4.8
+#configopts += '--set=llvm.ninja=false '           # In case you would want to avoid the use of ninja.
+configopts += '--enable-full-tools  '
+configopts += '--enable-lld '
+
+#
+# Build phase
+#
+
+# avoid failure when home directory is an NFS mount or some other file systems
+# see https://github.com/rust-lang/cargo/issues/6652
+prebuildopts  = local_module_conf
+prebuildopts += "export CARGO_HOME=%(builddir)s/cargo && " # Also extracted from the EasyBlock in 4.8."
+
+build_cmd = "./x.py build"
+
+#
+# Install phase
+#
+
+preinstallopts  = local_module_conf
+preinstallopts += "export CARGO_HOME=%(builddir)s/cargo && " # Also extracted from the EasyBlock in 4.8."
+
+install_cmd = "./x.py install -j %(parallel)s"
+
+
+sanity_check_paths = {
+    'files': ['bin/cargo', 'bin/rustc', 'bin/rustdoc'],
+    'dirs':  ['lib/rustlib', 'share/doc', 'share/man'],
+}
+
+sanity_check_commands = [
+    "cargo --version",
+    "rustc --version",
+]
+
+moduleclass = 'lang'
+

--- a/easybuild/easyconfigs/r/Rust/Rust-1.75_sysroot-fix-interpreter.patch
+++ b/easybuild/easyconfigs/r/Rust/Rust-1.75_sysroot-fix-interpreter.patch
@@ -1,0 +1,44 @@
+Use patchelf to fix interpreter of binaries that are used during Rust bootstrap procedure
+when EasyBuild is configured to build in an alternate sysroot
+
+This fixes problems like due to a clash with the interpreter from the host, and a more recent libc.so.6 that's picked up
+from the alternate sysroot:
+error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /tmp/easybuild/build/Rust/1.52.1/GCCcore-10.3.0/rustc-1.52.1-src/build/bootstrap/debug/deps/libproc_macro_error_attr-fbfef320d848b049.so)
+
+author: Kenneth Hoste (HPC-UGent)
+updated by: micketeer@gmail.com
+
+--- rustc-1.70.0-src.orig/src/bootstrap/bootstrap.py	2023-05-31 21:28:10.000000000 +0200
++++ rustc-1.70.0-src/src/bootstrap/bootstrap.py	2023-06-04 14:15:39.784929373 +0200
+@@ -481,6 +481,10 @@
+         if self._should_fix_bins_and_dylibs is not None:
+             return self._should_fix_bins_and_dylibs
+ 
++        if os.getenv("EASYBUILD_SYSROOT"):
++            self._should_fix_bins_and_dylibs = True
++            return True
++
+         def get_answer():
+             default_encoding = sys.getdefaultencoding()
+             try:
+@@ -531,6 +535,20 @@
+         assert self._should_fix_bins_and_dylibs is True
+         print("attempting to patch", fname)
+ 
++        easybuild_sysroot = os.getenv("EASYBUILD_SYSROOT")
++        if easybuild_sysroot:
++            if not fname.endswith(".so"):
++                # determine patch to interpreter in host via output produced by 'readelf -l /bin/bash'
++                readelf_out = subprocess.check_output(['readelf', '-l', '/bin/bash']).decode('ascii', 'ignore').strip()
++                regex = re.compile('.*program interpreter: ([^\]]+)', re.M)
++                res = regex.search(readelf_out)
++                interpreter_path = os.path.join(easybuild_sysroot, res.group(1).lstrip('/'))
++                if not os.path.exists(interpreter_path):
++                    raise Exception("Derived path to interpreter does not exist: %s" % interpreter_path)
++                cmd = ["patchelf", "--set-interpreter", interpreter_path, fname]
++                run(cmd, verbose=True)
++            return
++
+         # Only build `.nix-deps` once.
+         nix_deps_dir = self.nix_deps_dir
+         if not nix_deps_dir:


### PR DESCRIPTION
It also includes improved user documentation for HyperQueue for the LUMI Software Library.