### PR TITLE
{JSC Perftools}[LUMI/23.09] Add OTF2 v3.0.3, OPARI2 v2.0.8, CubeLib v4.8.2, CubeWriter v4.8.2, libbfd v2.42, Score-P v8.4 w/ ROCm 5.2, Scalasca v2.6.1

### DIFF
--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -1,0 +1,167 @@
+##
+# Copyright 2013-2024 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for software using the Score-P configuration style (e.g., Cube, OTF2, Scalasca, and Score-P),
+implemented as an easyblock.
+
+@author: Kenneth Hoste (Ghent University)
+@author: Bernd Mohr (Juelich Supercomputing Centre)
+@author: Markus Geimer (Juelich Supercomputing Centre)
+@author: Alexander Grund (TU Dresden)
+@author: Christian Feld (Juelich Supercomputing Centre)
+@author: Jan André Reuter (Juelich Supercomputing Centre)
+"""
+import easybuild.tools.toolchain as toolchain
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools import LooseVersion
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.environment import unset_env_vars
+from easybuild.tools.modules import get_software_root, get_software_libdir
+
+
+class EB_Score_minus_P(ConfigureMake):
+    """
+    Support for building and installing software using the Score-P configuration style (e.g., Cube, OTF2, Scalasca,
+    and Score-P).
+    """
+
+    def configure_step(self, *args, **kwargs):
+        """Configure the build, set configure options for compiler, MPI and dependencies."""
+        # Remove some settings from the environment, as they interfere with
+        # Score-P's configure magic...
+        unset_env_vars(['CPPFLAGS', 'LDFLAGS', 'LIBS'])
+
+        # On non-cross-compile platforms, specify compiler and MPI suite explicitly.  This is much quicker and safer
+        # than autodetection.  In Score-P build-system terms, the following platforms are considered cross-compile
+        # architectures:
+        #
+        #   - Cray XT/XE/XK/XC series
+        #   - Fujitsu FX10, FX100 & K computer
+        #   - IBM Blue Gene series
+        #
+        # Of those, only Cray is supported right now.
+        tc_fam = self.toolchain.toolchain_family()
+        if tc_fam != toolchain.CRAYPE:
+            # since 2024/03 releases: --with-nocross-compiler-suite=(cray|gcc|ibm|intel|oneapi|nvhpc|pgi|clang|aocc|amdclang)
+            comp_opts = {
+                # assume that system toolchain uses a system-provided GCC
+                toolchain.SYSTEM: 'gcc',
+                toolchain.AOCC: 'aocc',
+                toolchain.CCE: 'cray',
+                toolchain.GCC: 'gcc',
+                toolchain.IBMCOMP: 'ibm',
+                toolchain.INTELCOMP: 'intel',
+                toolchain.NVHPC: 'nvhpc',
+                toolchain.PGI: 'pgi',
+            }
+            nvhpc_since = {
+                'Score-P': '8.0',
+                'Scalasca': '2.6.1',
+                'OTF2': '3.0.2',
+                'CubeWriter': '4.8',
+                'CubeLib': '4.8',
+                'CubeGUI': '4.8',
+            }
+            if LooseVersion(self.version) < LooseVersion(nvhpc_since.get(self.name, '0')):
+                comp_opts[toolchain.NVHPC] = 'pgi'
+
+            comp_fam = self.toolchain.comp_family()
+            if comp_fam in comp_opts:
+                self.cfg.update('configopts', "--with-nocross-compiler-suite=%s" % comp_opts[comp_fam])
+            else:
+                raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
+                                     comp_fam, ', '.join(comp_opts.keys()))
+
+            # --with-mpi=(bullxmpi|cray||hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
+            #             platform|scali|sgimpt|sun)
+            #
+            # Notes:
+            #   - intel:    Intel MPI v1.x (ancient & unsupported)
+            #   - intel2:   Intel MPI v2.x and higher
+            #   - intelpoe: IBM POE MPI for Intel platforms
+            #   - mpich:    MPICH v1.x (ancient & unsupported)
+            #   - mpich2:   MPICH2 v1.x
+            #   - mpich3:   MPICH v3.x & MVAPICH2
+            #               This setting actually only affects options passed to the MPI (Fortran) compiler wrappers.
+            #               And since MPICH v3.x-compatible options were already supported in MVAPICH2 v1.7, it is
+            #               safe to use 'mpich3' for all supported versions although MVAPICH2 is based on MPICH v3.x
+            #               only since v1.9b.
+            #
+            # With minimal toolchains, packages using this easyblock may be built with a non-MPI toolchain (e.g., OTF2).
+            # In this case, skip passing the '--with-mpi' option.
+            mpi_opts = {
+                toolchain.CCE: 'cray',
+                toolchain.INTELMPI: 'intel2',
+                toolchain.OPENMPI: 'openmpi',
+                toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x
+                toolchain.MPICH2: 'mpich2',
+                toolchain.MVAPICH2: 'mpich3',
+            }
+            mpi_fam = self.toolchain.mpi_family()
+            if mpi_fam is not None:
+                # Cray compilers identify themselves as mpich3, but it is recommended to use the compiler wrappers
+                # instead. Therefore, switch to them when we detect CCE as our toolchain.
+                if self.toolchain.comp_family() == toolchain.CCE:
+                    mpi_fam = toolchain.CCE
+                if mpi_fam in mpi_opts:
+                    self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
+                else:
+                    raise EasyBuildError("MPI family %s not supported yet (only: %s)",
+                                         mpi_fam, ', '.join(mpi_opts.keys()))
+
+        # Auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
+        #
+        # Notes:
+        #   - binutils: Pass include/lib directories separately, as different directory layouts may break Score-P's
+        #               configure, see https://github.com/geimer/easybuild-easyblocks/pull/4#issuecomment-219284755
+        deps = {
+            'libbfd': ['--with-libbfd-include=%s/include',
+                         '--with-libbfd-lib=%%s/%s' % get_software_libdir('libbfd', fs=['libbfd.so'])],
+            'libunwind': ['--with-libunwind=%s'],
+            # Older versions use Cube
+            'Cube': ['--with-cube=%s/bin'],
+            # Recent versions of Cube are split into CubeLib and CubeW(riter)
+            'CubeLib': ['--with-cubelib=%s/bin'],
+            'CubeWriter': ['--with-cubew=%s/bin'],
+            'CUDA': ['--enable-cuda', '--with-libcudart=%s'],
+            'OTF2': ['--with-otf2=%s/bin'],
+            'OPARI2': ['--with-opari2=%s/bin'],
+            'PAPI': ['--with-papi-header=%s/include', '--with-papi-lib=%%s/%s' % get_software_libdir('PAPI')],
+            'PDT': ['--with-pdt=%s/bin'],
+            'Qt': ['--with-qt=%s'],
+            'SIONlib': ['--with-sionlib=%s/bin'],
+        }
+        for (dep_name, dep_opts) in deps.items():
+            dep_root = get_software_root(dep_name)
+            if dep_root:
+                for dep_opt in dep_opts:
+                    try:
+                        dep_opt = dep_opt % dep_root
+                    except TypeError:
+                        pass  # Ignore subtitution error when there is nothing to substitute
+                    self.cfg.update('configopts', dep_opt)
+
+        super(EB_Score_minus_P, self).configure_step(*args, **kwargs)
+

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeAOCC-23.09.eb
@@ -1,0 +1,60 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeLib'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd6fdef57b1bc9594f1450ba46cf08f431dd0d4ae595c47e2f3454e17e4ae74f4',  
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.a', 'lib64/libcube4.a'),
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeCray-23.09.eb
@@ -1,0 +1,60 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeLib'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd6fdef57b1bc9594f1450ba46cf08f431dd0d4ae595c47e2f3454e17e4ae74f4',  
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.a', 'lib64/libcube4.a'),
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.8.2-cpeGNU-23.09.eb
@@ -1,0 +1,60 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeLib'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd6fdef57b1bc9594f1450ba46cf08f431dd0d4ae595c47e2f3454e17e4ae74f4',  
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.a', 'lib64/libcube4.a'),
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/LICENSE.md
+++ b/easybuild/easyconfigs/c/CubeLib/LICENSE.md
@@ -1,0 +1,1 @@
+The CubeLib license agreement can be found [here](https://scalasca.org/scalasca/front_content.php?idart=1094).

--- a/easybuild/easyconfigs/c/CubeLib/README.md
+++ b/easybuild/easyconfigs/c/CubeLib/README.md
@@ -1,0 +1,13 @@
+CubeLib
+===
+
+- [CubeLib web site](https://www.scalasca.org/scalasca/software/cube-4.x/download.html)
+
+Cube, which is used as performance report explorer for Scalasca and Score-P, is a generic tool for displaying a multi-dimensional performance space consisting of the dimensions (i) performance metric, (ii) call path, and (iii) system resource. Each dimension can be represented as a tree, where non-leaf nodes of the tree can be collapsed or expanded to achieve the desired level of granularity. In addition, Cube can display multi-dimensional Cartesian process topologies.
+
+The Cube 4.x series report explorer and the associated Cube4 data format is provided for Cube files produced with the Score-P performance instrumentation and measurement infrastructure or the Scalasca version 2.x trace analyzer (and other compatible tools). However, for backwards compatibility, Cube 4.x can also read and display Cube 3.x data.
+
+## EasyBuild support
+
+- [CubeLib support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/c/CubeLib)
+- [CubeLib support in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/c/CubeLib)

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeAOCC-23.09.eb
@@ -1,0 +1,58 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeWriter'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4f3bcf0622c2429b8972b5eb3f14d79ec89b8161e3c1cc5862ceda417d7975d2',  # cubew-4.8.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True)
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.a', 'lib64/libcube4w.a'),
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeCray-23.09.eb
@@ -1,0 +1,58 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeWriter'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4f3bcf0622c2429b8972b5eb3f14d79ec89b8161e3c1cc5862ceda417d7975d2',  # cubew-4.8.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True)
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.a', 'lib64/libcube4w.a'),
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.8.2-cpeGNU-23.09.eb
@@ -1,0 +1,58 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'CubeWriter'
+version = '4.8.2'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4f3bcf0622c2429b8972b5eb3f14d79ec89b8161e3c1cc5862ceda417d7975d2',  # cubew-4.8.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True)
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.a', 'lib64/libcube4w.a'),
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/LICENSE.md
+++ b/easybuild/easyconfigs/c/CubeWriter/LICENSE.md
@@ -1,0 +1,1 @@
+The CubeWriter license agreement can be found [here](https://scalasca.org/scalasca/front_content.php?idart=1094).

--- a/easybuild/easyconfigs/c/CubeWriter/README.md
+++ b/easybuild/easyconfigs/c/CubeWriter/README.md
@@ -1,0 +1,13 @@
+CubeWriter
+===
+
+- [CubeWriter web site](https://www.scalasca.org/scalasca/software/cube-4.x/download.html)
+
+Cube, which is used as performance report explorer for Scalasca and Score-P, is a generic tool for displaying a multi-dimensional performance space consisting of the dimensions (i) performance metric, (ii) call path, and (iii) system resource. Each dimension can be represented as a tree, where non-leaf nodes of the tree can be collapsed or expanded to achieve the desired level of granularity. In addition, Cube can display multi-dimensional Cartesian process topologies.
+
+The Cube 4.x series report explorer and the associated Cube4 data format is provided for Cube files produced with the Score-P performance instrumentation and measurement infrastructure or the Scalasca version 2.x trace analyzer (and other compatible tools). However, for backwards compatibility, Cube 4.x can also read and display Cube 3.x data.
+
+## EasyBuild support
+
+- [CubeWriter support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/c/CubeWriter)
+- [CubeWriter support in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/c/CubeW)

--- a/easybuild/easyconfigs/l/libbfd/README.md
+++ b/easybuild/easyconfigs/l/libbfd/README.md
@@ -1,0 +1,30 @@
+# libbfd 
+
+* [binutils home page](https://directory.fsf.org/project/binutils/)
+
+libbfd is distrubuted as part of binutils 
+
+BFD is a package which allows applications to use the same routines to operate
+on object files whatever the object file format. A new object file format can
+be supported simply by creating a new BFD back end and adding it to the library.
+
+BFD is split into two parts: the front end, and the back ends (one for each
+object file format).
+
+- The front end of BFD provides the interface to the user. It manages memory
+  and various canonical data structures. The front end also decides which back
+  end to use and when to call back end routines.
+- The back ends provide BFD its view of the real world. Each back end provides
+  a set of calls which the BFD front end can use to maintain its canonical
+  form. The back ends also may keep around information for their own use, for
+  greater efficiency.
+
+This package also include libiberty as most tools requiring libbfd also
+requires it.
+
+## EasyBuild
+
+### Version 2.42 for CPE 23.09
+
+  * Created for LUMI
+  

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeAOCC-23.09.eb
@@ -1,0 +1,79 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+name = 'libbfd'
+version = '2.42'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.42/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['5d2a6c1d49686a557869caae08b6c2e83699775efd27505e01b2f4db1a024ffc']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeCray-23.09.eb
@@ -1,0 +1,79 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+name = 'libbfd'
+version = '2.42'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.42/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['5d2a6c1d49686a557869caae08b6c2e83699775efd27505e01b2f4db1a024ffc']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.42-cpeGNU-23.09.eb
@@ -1,0 +1,79 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+name = 'libbfd'
+version = '2.42'
+
+local_zlib_version = '1.2.13'
+
+homepage = 'https://directory.fsf.org/project/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.42/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['5d2a6c1d49686a557869caae08b6c2e83699775efd27505e01b2f4db1a024ffc']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OPARI2/LICENSE.md
+++ b/easybuild/easyconfigs/o/OPARI2/LICENSE.md
@@ -1,0 +1,1 @@
+OPARI2 is available under the 3-clause BSD Open Source license.

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeAOCC-23.09.eb
@@ -1,0 +1,47 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'OPARI2'
+version = '2.0.8'
+
+homepage = 'https://www.score-p.org'
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721',  # opari2-2.0.8.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeCray-23.09.eb
@@ -1,0 +1,47 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'OPARI2'
+version = '2.0.8'
+
+homepage = 'https://www.score-p.org'
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721',  # opari2-2.0.8.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.8-cpeGNU-23.09.eb
@@ -1,0 +1,47 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+              Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'OPARI2'
+version = '2.0.8'
+
+homepage = 'https://www.score-p.org'
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '196e59a2a625e6c795a6124c61e784bad142f9f38df0b4fa4d435ba9b9c19721',  # opari2-2.0.8.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/README.md
+++ b/easybuild/easyconfigs/o/OPARI2/README.md
@@ -1,0 +1,11 @@
+OPARI2
+===
+
+- [OPARI2 web site](https://www.vi-hps.org/tools/opari2.html)
+
+OPARI2, the successor of Forschungszentrum Jülich's OPARI, is a source-to-source instrumentation tool for OpenMP and hybrid codes. It surrounds OpenMP directives and runtime library calls with calls to the POMP2 measurement interface. The POMP2 interface can be implemented by tool builders who want, for example, to monitor the performance of OpenMP applications. Like its predecessor, OPARI2 works with Fortran, C, and C++ programs. Additional features compared to OPARI are a new initialization method that allows for multi-directory and parallel builds as well as the usage of pre-instrumented libraries. Furthermore, an efficient way of tracking parent-child thread-relationships was added. Additionally OPARI2 was extended to support instrumentation of OpenMP 3.0 tied tasks. OPARI is used by many performance analysis tools (e.g. TAU, ompP, KOJAK, Scalasca, VampirTrace) whereas OPARI2 is currently used by Score-P and TAU.
+
+## EasyBuild support
+
+- [OPARI2 support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/o/OPARI2)
+- [OPARI2 support in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/o/OPARI2)

--- a/easybuild/easyconfigs/o/OTF2/LICENSE.md
+++ b/easybuild/easyconfigs/o/OTF2/LICENSE.md
@@ -1,0 +1,1 @@
+OTF2 is available under the 3-clause BSD Open Source license.

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAOCC-23.09.eb
@@ -1,0 +1,48 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'OTF2'
+version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8',  # otf2-3.0.3.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.a', 'lib64/libotf2.a'),
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeCray-23.09.eb
@@ -1,0 +1,48 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'OTF2'
+version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8',  # otf2-3.0.3.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.a', 'lib64/libotf2.a'),
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeGNU-23.09.eb
@@ -1,0 +1,48 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'OTF2'
+version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8',  # otf2-3.0.3.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.a', 'lib64/libotf2.a'),
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/README.md
+++ b/easybuild/easyconfigs/o/OTF2/README.md
@@ -1,0 +1,13 @@
+OTF2
+===
+
+- [OTF2 web site](https://www.vi-hps.org/projects/score-p)
+
+The Open Trace Format Version 2 (OTF2) is a highly scalable, memory efficient event trace data format plus support library. It is the standard trace format for Scalasca, Vampir, and Tau and is open for other tools.
+
+OTF2 is the common successor format for the Open Trace Format (OTF) and the Epilog trace format. It preserves the essential features as well as most record types of both and introduces new features such as support for multiple read/write substrates, in-place time stamp manipulation, and on-the-fly token translation. In particular, it will avoid copying during unification of parallel event streams.
+
+## EasyBuild support
+
+- [OTF2 support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/o/OTF2)
+- [OTF2 support in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/o/OTF2)

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAOCC-23.09.eb
@@ -1,0 +1,76 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Scalasca'
+version = '2.6.1'
+
+local_cubewriter_version = '4.8.2'
+local_cubelib_version = '4.8.2'
+local_otf2_version = '3.0.3'
+local_scorep_version = '8.4'
+
+homepage = 'https://www.scalasca.org/'
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analyzing their runtime behavior. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+builddependencies = [
+    ('CubeWriter', local_cubewriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('OTF2', local_otf2_version),
+    ('Score-P', local_scorep_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeCray-23.09.eb
@@ -1,0 +1,76 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Scalasca'
+version = '2.6.1'
+
+local_cubewriter_version = '4.8.2'
+local_cubelib_version = '4.8.2'
+local_otf2_version = '3.0.3'
+local_scorep_version = '8.4'
+
+homepage = 'https://www.scalasca.org/'
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analyzing their runtime behavior. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+builddependencies = [
+    ('CubeWriter', local_cubewriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('OTF2', local_otf2_version),
+    ('Score-P', local_scorep_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeGNU-23.09.eb
@@ -1,0 +1,76 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Scalasca'
+version = '2.6.1'
+
+local_cubewriter_version = '4.8.2'
+local_cubelib_version = '4.8.2'
+local_otf2_version = '3.0.3'
+local_scorep_version = '8.4'
+
+homepage = 'https://www.scalasca.org/'
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analyzing their runtime behavior. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+builddependencies = [
+    ('CubeWriter', local_cubewriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('OTF2', local_otf2_version),
+    ('Score-P', local_scorep_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1_nowarn_omp_pragmas.patch
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1_nowarn_omp_pragmas.patch
@@ -1,0 +1,36 @@
+diff -Nrup scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4 scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4
+--- scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2022-12-14 11:55:38.810618928 +0100
++++ scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2023-09-27 09:47:31.155201804 +0200
+@@ -62,7 +62,7 @@ AS_CASE([$_scalasca_nowarn_omp_pragmas],
+ AC_SUBST([NOWARN_OMP_PRAGMAS_]_AC_LANG_PREFIX[FLAGS])
+ 
+ dnl Reset environment
+-ac_[]_AC_LANG_ABBREV[]_werror_flag=_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
++ac_[]_AC_LANG_ABBREV[]_werror_flag=$_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
+ ])
+ 
+ 
+diff -Nrup scalasca-2.6.1.orig/build-backend/configure scalasca-2.6.1/build-backend/configure
+--- scalasca-2.6.1.orig/build-backend/configure	2022-12-14 11:56:16.350709778 +0100
++++ scalasca-2.6.1/build-backend/configure	2023-09-27 09:49:35.847822426 +0200
+@@ -21128,7 +21128,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then
+diff -Nrup scalasca-2.6.1.orig/build-mpi/configure scalasca-2.6.1/build-mpi/configure
+--- scalasca-2.6.1.orig/build-mpi/configure	2022-12-14 11:56:33.574751469 +0100
++++ scalasca-2.6.1/build-mpi/configure	2023-09-27 09:49:06.135678364 +0200
+@@ -21878,7 +21878,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then

--- a/easybuild/easyconfigs/s/Score-P/LICENSE.md
+++ b/easybuild/easyconfigs/s/Score-P/LICENSE.md
@@ -1,0 +1,1 @@
+Score-P is available under the 3-clause BSD Open Source license.

--- a/easybuild/easyconfigs/s/Score-P/README.md
+++ b/easybuild/easyconfigs/s/Score-P/README.md
@@ -1,0 +1,15 @@
+Score-P
+===
+
+- [Score-P web site](https://www.vi-hps.org/projects/score-p)
+
+The Score-P measurement infrastructure is a highly scalable and easy-to-use tool suite for profiling and event tracing of HPC applications.
+
+It has been created in the German BMBF project SILC and the US DOE project PRIMA and will be maintained and enhanced in a number of follow-up projects such as LMAC, Score-E, and HOPSA. Score-P is developed under a BSD 3-Clause License and governed by a meritocratic governance model.
+
+Score-P offers the user a maximum of convenience by supporting a number of analysis tools. Currently, it works with Scalasca, Vampir, and Tau and is open for other tools. Score-P comes together with the new Open Trace Format Version 2, the Cube4 profiling format and the OPARI2 instrumenter.
+
+## EasyBuild support
+
+- [Score-P support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/s/Score-P)
+- [Score-P support in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/s/Score-P)

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAOCC-23.09.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAOCC-23.09.eb
@@ -1,0 +1,83 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'Score-P'
+version = '8.4'
+
+local_cubelib_version = '4.8.2'
+local_cubewriter_version = '4.8.2'
+local_libunwind_version = '1.6.2'
+local_libbfd_version = '2.42'
+local_opari_version = '2.0.8'
+local_otf_version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('CubeWriter', local_cubewriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind', local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2', local_opari_version),
+    ('OTF2',   local_otf_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd', local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi', EXTERNAL_MODULE),
+    # Support for HIP adapter
+    ('rocm', EXTERNAL_MODULE),
+]
+
+configopts = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-23.09.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-23.09.eb
@@ -1,0 +1,82 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'Score-P'
+version = '8.4'
+
+local_cubelib_version = '4.8.2'
+local_cubewriter_version = '4.8.2'
+local_libunwind_version = '1.6.2'
+local_libbfd_version = '2.42'
+local_opari_version = '2.0.8'
+local_otf_version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('CubeWriter', local_cubewriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind', local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2', local_opari_version),
+    ('OTF2',   local_otf_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd', local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi', EXTERNAL_MODULE),
+    # Support for HIP adapter
+    ('rocm', EXTERNAL_MODULE),
+]
+
+configopts = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+configopts += '--with-rocm=$ROCM_PATH '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-23.09.eb
@@ -1,0 +1,79 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'Score-P'
+version = '8.4'
+
+local_cubelib_version = '4.8.2'
+local_cubewriter_version = '4.8.2'
+local_libunwind_version = '1.6.2'
+local_libbfd_version = '2.42'
+local_opari_version = '2.0.8'
+local_otf_version = '3.0.3'
+
+homepage = 'https://www.score-p.org'
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('CubeLib', local_cubelib_version),
+    ('CubeWriter', local_cubewriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind', local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2', local_opari_version),
+    ('OTF2',   local_otf_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd', local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi', EXTERNAL_MODULE),
+]
+
+configopts = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
@@ -1,0 +1,19 @@
+Fixes make installcheck failing due to libraries incorrectly being parsed when
+generating library dependencies. This also caused any instrumentation with MPI
+to fail. This issue is only noticed with Crays ftn compiler.
+--- a/build-config/common/generate-library-dependencies.sh
++++ b/build-config/common/generate-library-dependencies.sh
+@@ -148,7 +148,12 @@ parse_la ()
+     done
+ 
+     for i in ${ldflags}; do
+-        printf '    ldflags.push_back( "%s" );\n' "${i}"
++        case ${i} in
++            -L*)
++                printf '    ldflags.push_back( "%s" );\n' "${i}" ;;
++            *)
++                printf '    ldflags.push_back( "-L%s" );\n' "${i}" ;;
++        esac
+     done
+ 
+     for i in ${rpath}; do


### PR DESCRIPTION
As mentioned in the last LUMI Coffee break, we are interested in providing the current Score-P release for users on the LUMI HPC system. Score-P v8.x includes support for instrumentation of HIP code via ROCm for the first time which might be interesting for users of the system. 

All modules are available for cpeAOCC, cpeCray and cpeGNU. If wanted, we may be able to add additional installations for the other programming environments.

Our perftools modules are based on the upstream EasyBuild repository and our adaption in the [JSC repository](https://github.com/easybuilders/JSC). Some changes were needed to support Score-P v8.4 correctly, since we ran into issues with `ftn` and `autotools`. Therefore, a patch is included. Without this patch, instrumentation of MPI installations (and `make installcheck` during the installation) would fail. 

Things to note:
- cpeGNU will not offer support for our HIP adapter, as we require a Clang based compiler. It is available for the others.
- cpeAOCC will offer support for the OpenMP Tools Interface and enables it by default. This is an alternative to OPARI2 and provides support for a wider range of OpenMP. GNU GCC lacks the interface, CCE 16 still has some issues, where we decide to not enable the adapter. 

Current state of the MR:
- [x] OTF2 3.0.3
- [x] OPARI2 2.0.8
- [x] CubeLib 4.8.2
- [x] CubeWriter 4.8.2
- [x] libbfd 2.42
- [x] Score-P 8.4
- [x] Scalasca 2.6.1

All EasyBuild recipes were tested via User Installations on LUMI/L.