### PR TITLE
Update PyTorch documentation. 

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/USER.md
+++ b/easybuild/easyconfigs/p/PyTorch/USER.md
@@ -8,6 +8,10 @@ talk to a proper version of the
 [AWS OFI RCCL plugin](https://github.com/ROCmSoftwarePlatform/aws-ofi-rccl) which is needed for
 proper communication on the Slingshot 11 interconnect of LUMI.
 
-We now provide prebuilt singularity containers that you can find below,
-and an EasyBuild-generated module around them that eases work with those
-containers.
+We now provide prebuilt singularity containers
+with EasyBuild-generated module around them that eases work with those
+containers. The use is documented in the next section, 
+["User documentation (singularity container)"](index.md#user-documentation-singularity-container)
+while the user-installable EasyBuild recipes for each container can
+be found in the 
+["Singularity containers with modules for binding and extras" section](index.md#singularity-containers-with-modules-for-binding-and-extras).


### PR DESCRIPTION
The links will be dead when using them in the USER.md file in GitHub but were needed to make the documentation in the LUMI Software Library more readable.