### PR TITLE
GPAW recipe for LUMI

### DIFF
--- a/easybuild/easyconfigs/c/CuPy/CuPy-12.2.0-cpeGNU-22.09-rocm-5.2.3.eb
+++ b/easybuild/easyconfigs/c/CuPy/CuPy-12.2.0-cpeGNU-22.09-rocm-5.2.3.eb
@@ -1,0 +1,53 @@
+easyblock = 'PythonPackage'
+
+name = 'CuPy'
+version = '12.2.0'
+versionsuffix = '-rocm-5.2.3'
+
+homepage = 'https://cupy.dev'
+
+whatis = [
+    'Description: CuPy is an open-source array library for GPU-accelerated computing with Python'
+]
+
+description = """"
+CuPy is an open-source array library for GPU-accelerated computing with Python.
+CuPy acts as a drop-in replacement to run existing NumPy/SciPy code on NVIDIA CUDA
+or AMD ROCm platforms.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('cray-python/3.10.10', EXTERNAL_MODULE),
+    ('rocm/5.2.3', EXTERNAL_MODULE)
+]
+
+use_pip = True
+
+preinstallopts = ('export ROCM_HOME=$(readlink -f $ROCM_PATH) && '
+                  'export CUPY_INSTALL_USE_HIP=1 && '
+                  'export HCC_AMDGPU_TARGET=gfx90a && '
+                  )
+
+skipsteps = ['build']
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True
+}
+exts_list = [
+    ('fastrlock', '0.8.2')
+]
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/cupyx/cusolver.cpython-310-x86_64-linux-gnu.so',
+              'lib/python%(pyshortver)s/site-packages/fastrlock/rlock.cpython-310-x86_64-linux-gnu.so'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-cpeGNU-23.09-rocm-5.2.3.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2023.11.001-cpeGNU-23.09-rocm-5.2.3.eb
@@ -1,0 +1,89 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+# GPU version adapted for LUMI
+easyblock = 'ConfigureMake'
+
+local_ELPA_version = '2023.11.001'
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-rocm-5.2.3'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True, 'openmp': False}
+
+source_urls = ['https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/%(version)s/']
+sources =     ['elpa-%(version)s-patched.tar.gz']
+
+patches = [
+    {'name': 'elpa-2023.11.01-hiputils.patch', 'level': 1},
+]
+
+builddependencies = [ 
+    ('buildtools', '%(toolchain_version)s', '', True), 
+]
+
+dependencies = [
+    ('cray-libsci/23.09.1.1', EXTERNAL_MODULE),
+    ('rocm/5.2.3', EXTERNAL_MODULE),
+]
+
+local_commonopts  = 'CPP=cpp CC=cc CXX=hipcc FC=ftn CFLAGS="-g $CFLAGS" FCFLAGS="-g $FCFLAGS" CXXFLAGS="-g --offload-arch=gfx90a --gcc-toolchain=$GCC_PATH/snos -std=c++17 -I$ROCM_PATH/include/hip -I$ROCM_PATH/include/rocblas -I$CRAY_MPICH_DIR/include" '
+local_commonopts += '--enable-static '
+local_commonopts += '--disable-generic '
+local_commonopts += '--disable-sse '
+local_commonopts += '--disable-avx '
+local_commonopts += '--enable-avx2 '
+local_commonopts += '--disable-avx512 ' 
+local_commonopts += '--enable-amd-gpu-kernels '
+local_commonopts += '--with-AMD-gpu-support-only ' 
+local_commonopts += '--enable-gpu-streams=amd '
+local_commonopts += '--enable-hipcub '
+local_commonopts += '--enable-single-precision '
+local_commonopts += '--disable-openmp '
+local_commonopts += '--with-mpi=yes '
+local_commonopts += '--enable-cuda-aware-mpi '
+local_commonopts += '--enable-marshalling-hipblas-library '
+
+configopts = local_commonopts
+
+prebuildopts = " make clean && "
+
+maxparallel = 16
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules',]
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s',
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
@@ -1,0 +1,60 @@
+# This follows instructions from https://gitlab.com/trossi/gpaw/-/tree/update-lumi-docs
+easyblock = "PythonPackage"
+
+name = 'GPAW'
+version = '24.1.0'
+versionsuffix = '-rocm-5.2.3'
+
+homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
+description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
+ method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or
+ atom-centered basis-functions."""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True, 'openmp': False}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://gitlab.com/gpaw',
+        'repo_name': 'gpaw',
+        'commit': '%(version)s',
+    }
+}]
+
+patches = [
+   {'name': 'gpaw-gpu-disable-openmp.patch', 'level': 1},
+]
+
+dependencies = [
+    ('cray-python/3.10.10', EXTERNAL_MODULE),
+    ('cray-libsci/23.09.1.1', EXTERNAL_MODULE),
+    ('cray-fftw/3.3.10.5', EXTERNAL_MODULE),
+    ('rocm/5.2.3', EXTERNAL_MODULE),
+    ('CuPy', '12.2.0', '-rocm-5.2.3'),
+    ('libxc', '6.2.2'),
+    ('ELPA', '2023.11.001', '-rocm-5.2.3'),
+]
+
+prebuildopts = 'GPAW_CONFIG=doc/platforms/Cray/siteconfig-lumi-gpu.py '
+preinstallopts = prebuildopts
+
+download_dep_fail = False
+use_pip = True
+use_pip_for_deps = True
+pip_verbose = True
+pip_ignore_installed = False
+pip_no_index = False
+sanity_pip_check = True
+
+postinstallcmds = ['export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && %(installdir)s/bin/gpaw install-data --no-register %(installdir)s']
+
+sanity_check_paths = {
+    'files': ['bin/gpaw%s' % x for x in ['', '-analyse-basis', '-basis', '-plot-parallel-timings',
+                                         '-runscript', '-setup', '-upfplot']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+modextravars = {'GPAW_SETUP_PATH': '%(installdir)s/gpaw-setups-%(version)s'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
@@ -20,7 +20,13 @@ sources = [{
         'repo_name': 'gpaw',
         'commit': '%(version)s',
     }
-}]
+},
+{
+     'source_urls': ['https://wiki.fysik.dtu.dk/gpaw-files/'],
+     'filename': 'gpaw-setups-%(version)s.tar.gz',
+     'extract_cmd': 'mkdir -p %(installdir)s/gpaw-setups-%(version)s && tar xfvz %s -C %(installdir)s/gpaw-setups-%(version)s',
+}
+]
 
 patches = [
    {'name': 'gpaw-gpu-disable-openmp.patch', 'level': 1},
@@ -36,8 +42,7 @@ dependencies = [
     ('ELPA', '2023.11.001', '-rocm-5.2.3'),
 ]
 
-prebuildopts = 'GPAW_CONFIG=doc/platforms/Cray/siteconfig-lumi-gpu.py '
-preinstallopts = prebuildopts
+preinstallopts = 'GPAW_CONFIG=doc/platforms/Cray/siteconfig-lumi-gpu.py '
 
 download_dep_fail = False
 use_pip = True
@@ -47,7 +52,8 @@ pip_ignore_installed = False
 pip_no_index = False
 sanity_pip_check = True
 
-postinstallcmds = ['export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && %(installdir)s/bin/gpaw install-data --no-register %(installdir)s']
+#postinstallcmds = ['export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && %(installdir)s/bin/gpaw install-data --no-register %(installdir)s']
+#postinstallcmds = ['mkdir %(installdir)s/gpaw-setups-%(version)s && ']
 
 sanity_check_paths = {
     'files': ['bin/gpaw%s' % x for x in ['', '-analyse-basis', '-basis', '-plot-parallel-timings',

--- a/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09-rocm-5.2.3.eb
@@ -22,14 +22,19 @@ sources = [{
     }
 },
 {
-     'source_urls': ['https://wiki.fysik.dtu.dk/gpaw-files/'],
      'filename': 'gpaw-setups-%(version)s.tar.gz',
-     'extract_cmd': 'mkdir -p %(installdir)s/gpaw-setups-%(version)s && tar xfvz %s -C %(installdir)s/gpaw-setups-%(version)s',
+     'source_urls': ['https://wiki.fysik.dtu.dk/gpaw-files/'],
 }
 ]
 
 patches = [
    {'name': 'gpaw-gpu-disable-openmp.patch', 'level': 1},
+]
+
+checksums = [
+    '38d2f53cf00dd9b2f21fcf032d17f783d640105ee8544e897d260b429ea7ed07',
+    '314d43168f7b57a2d942855d3d5ad21da9ef74e772d37343d416305113a95c23',
+    '152648015971fc9ddc33a16769bb17acb90eacfa38d4b9c49aa91c4c2a99da2a',
 ]
 
 dependencies = [
@@ -52,8 +57,7 @@ pip_ignore_installed = False
 pip_no_index = False
 sanity_pip_check = True
 
-#postinstallcmds = ['export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && %(installdir)s/bin/gpaw install-data --no-register %(installdir)s']
-#postinstallcmds = ['mkdir %(installdir)s/gpaw-setups-%(version)s && ']
+postinstallcmds = ['cp -rp ../gpaw-setups-%(version)s %(installdir)s/']
 
 sanity_check_paths = {
     'files': ['bin/gpaw%s' % x for x in ['', '-analyse-basis', '-basis', '-plot-parallel-timings',

--- a/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-24.1.0-cpeGNU-23.09.eb
@@ -1,0 +1,67 @@
+# This follows instructions from https://gitlab.com/trossi/gpaw/-/tree/update-lumi-docs
+easyblock = "PythonPackage"
+
+name = 'GPAW'
+version = '24.1.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
+description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
+ method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or
+ atom-centered basis-functions."""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.09'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://gitlab.com/gpaw',
+        'repo_name': 'gpaw',
+        'commit': '%(version)s',
+    }
+},
+{
+     'filename': 'gpaw-setups-%(version)s.tar.gz',
+     'source_urls': ['https://wiki.fysik.dtu.dk/gpaw-files/'],
+}
+]
+
+patches = [
+# This is diff generated from merge request #2065 
+# https://gitlab.com/gpaw/gpaw/-/merge_requests/2065/diffs
+   {'name': 'gpaw-update-lumi.patch', 'level': 1},
+]
+
+checksums = [
+    '38d2f53cf00dd9b2f21fcf032d17f783d640105ee8544e897d260b429ea7ed07',
+    '314d43168f7b57a2d942855d3d5ad21da9ef74e772d37343d416305113a95c23',
+]
+
+dependencies = [
+    ('cray-python/3.10.10', EXTERNAL_MODULE),
+    ('cray-libsci/23.09.1.1', EXTERNAL_MODULE),
+    ('cray-fftw/3.3.10.5', EXTERNAL_MODULE),
+    ('libxc', '6.2.2'),
+]
+
+preinstallopts = 'GPAW_CONFIG=doc/platforms/Cray/siteconfig-lumi-cpu.py '
+
+download_dep_fail = False
+use_pip = True
+use_pip_for_deps = True
+pip_verbose = True
+pip_ignore_installed = False
+pip_no_index = False
+sanity_pip_check = True
+
+postinstallcmds = ['cp -rp ../gpaw-setups-%(version)s %(installdir)s/']
+
+sanity_check_paths = {
+    'files': ['bin/gpaw%s' % x for x in ['', '-analyse-basis', '-basis', '-plot-parallel-timings',
+                                         '-runscript', '-setup', '-upfplot']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+modextravars = {'GPAW_SETUP_PATH': '%(installdir)s/gpaw-setups-%(version)s'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/gpaw-gpu-disable-openmp.patch
+++ b/easybuild/easyconfigs/g/GPAW/gpaw-gpu-disable-openmp.patch
@@ -1,0 +1,17 @@
+diff -Naur gpaw/doc/platforms/Cray/siteconfig-lumi-gpu.py gpaw-update-lumi-docs/doc/platforms/Cray/siteconfig-lumi-gpu.py
+--- gpaw/doc/platforms/Cray/siteconfig-lumi-gpu.py	2024-05-22 15:22:29.000000000 +0300
++++ gpaw-update-lumi-docs/doc/platforms/Cray/siteconfig-lumi-gpu.py	2024-05-22 15:27:43.000000000 +0300
+@@ -10,13 +10,11 @@
+     '-march=native',
+     '-mtune=native',
+     '-mavx2',
+-    '-fopenmp',
+     '-fPIC',
+     '-Wall',
+     '-Wno-stringop-overflow',  # suppress warnings from MPI_STATUSES_IGNORE
+     '-DNDEBUG',
+     '-g']
+-extra_link_args = ['-fopenmp']
+ 
+ # hip
+ gpu = True

--- a/easybuild/easyconfigs/g/GPAW/gpaw-update-lumi.patch
+++ b/easybuild/easyconfigs/g/GPAW/gpaw-update-lumi.patch
@@ -1,0 +1,320 @@
+diff --git a/doc/platforms/Cray/lumi.rst b/doc/platforms/Cray/lumi.rst
+index 512da442a89339df6fca803e33eccbad62a16e67..6dea4da0b890e6c116f5cfa6cc11c56a526c0450 100644
+--- a/doc/platforms/Cray/lumi.rst
++++ b/doc/platforms/Cray/lumi.rst
+@@ -5,58 +5,173 @@ The ``lumi.csc.fi`` supercomputer
+ =================================
+ 
+ .. note::
+-   These instructions are up-to-date as of September 2023.
++   These instructions are up-to-date as of February 2024.
+ 
+-It is recommended to perform installation under the
+-``/projappl/project_...`` directory (see `LUMI user documentation
+-<https://docs.lumi-supercomputer.eu/storage/>`_). A separate installation
+-is needed for LUMI-C and LUMI-G.
++It is recommended to perform the installations under
++the ``/projappl/project_...`` directory
++(see `LUMI user documentation <https://docs.lumi-supercomputer.eu/storage/>`_).
++A separate installation is needed for LUMI-C and LUMI-G.
+ 
+ 
+ GPAW for LUMI-G
+ ===============
+ 
+-Load the following modules:
++First, install required libraries as EasyBuild modules
++(see `LUMI user documentation <https://docs.lumi-supercomputer.eu/software/installing/easybuild/>`_
++for detailed description):
+ 
+ .. code-block:: bash
+ 
+-  export EBU_USER_PREFIX=/scratch/project_465000538/GPAW/EasyBuild
++  # Setup environment
++  # TODO: use correct project_...
++  export EBU_USER_PREFIX=/projappl/project_.../EasyBuild
++  module load LUMI/22.12 partition/G
++  module load cpeGNU/22.12
++  module load rocm/5.2.3
++  module load EasyBuild-user
++
++  # Install CuPy
++  eb CuPy-12.2.0-cpeGNU-22.12.eb -r
++
++  # Install libxc
++  eb libxc-6.2.2-cpeGNU-22.12.eb -r
++
++The above EasyBuild setup is needed only once.
++
++Then, the following steps build GPAW in a Python virtual environment:
++
++.. code-block:: bash
++
++  # Create virtual environment
++  module load cray-python/3.9.13.1
++  python3 -m venv --system-site-packages venv-gpaw-gpu
++
++  # The following will insert environment setup to the beginning of venv/bin/activate
++  # TODO: use correct project_...
++  cp venv-gpaw-gpu/bin/activate venv-gpaw-gpu/bin/activate.old
++  cat << EOF > venv-gpaw-gpu/bin/activate
++  export EBU_USER_PREFIX=/projappl/project_.../EasyBuild
++  export GPAW_SETUP_PATH=/projappl/project_.../gpaw-setups-0.9.20000
+   module load LUMI/22.12 partition/G
+   module load cpeGNU/22.12
+-  module load craype-accel-amd-gfx90a
+   module load rocm/5.2.3
+   module load cray-python/3.9.13.1
+   module load cray-fftw/3.3.10.1
+-  module load ASE/3.22.1-cpeGNU-22.12
+-  module load CuPy/12.2.0-cpeGNU-22.12
+-  module load ELPA/2023.05.001-cpeGNU-22.12-GPU
+-  module load libxc/6.2.2-cpeGNU-22.12
++  module load CuPy/12.2.0-cpeGNU-22.12  # from EBU_USER_PREFIX
++  module load libxc/6.2.2-cpeGNU-22.12  # from EBU_USER_PREFIX
++  EOF
++  cat venv-gpaw-gpu/bin/activate.old >> venv-gpaw-gpu/bin/activate
++
++  # Activate venv
++  source venv-gpaw-gpu/bin/activate
++
++  # Install GPAW development version
++  git clone git@gitlab.com:gpaw/gpaw.git
++  export GPAW_CONFIG=$(readlink -f gpaw/doc/platforms/Cray/siteconfig-lumi-gpu.py)
++  cd gpaw
++  rm -rf build _gpaw.*.so gpaw.egg-info
++  pip install -v --log build-gpu.log .
++
++  # Install gpaw setups
++  # TODO: use correct project_...
++  gpaw install-data --no-register /projappl/project_...
++
++Note that above the siteconfig file is taken from the git clone.
++If you are not using installation through git, use the siteconfig file from here:
++:git:`~doc/platforms/Cray/siteconfig-lumi-gpu.py`.
++
++Interactive jobs can be run like this::
++
++  srun -A project_... -p small-g --nodes=1 --ntasks-per-node=1 --gpus-per-node=1 -t 0:30:00 --pty bash
++
++One-liner to run GPU tests::
++
++  n=1; sbatch -p small-g --nodes=1 --ntasks-per-node=$n --gpus-per-node=$n -t 00:30:00 -J pytest-gpu-$n -o %x.out --wrap="srun gpaw python -m pytest --pyargs gpaw -v -m gpu"
++
+ 
+-Create a virtual environment and activate it::
++Omnitrace
++---------
+ 
+-  python3 -m venv venv
+-  source venv/bin/activate
++To install `Omnitrace <https://github.com/AMDResearch/omnitrace>`_
++(if using custon ROCm, use the correct ROCm version of the installer)::
+ 
+-Clone the GPAW source code::
++  cd /projappl/project_...
++  wget https://github.com/AMDResearch/omnitrace/releases/download/v1.10.4/omnitrace-1.10.4-opensuse-15.4-ROCm-50200-PAPI-OMPT-Python3.sh
++  bash omnitrace-1.10.4-opensuse-15.4-ROCm-50200-PAPI-OMPT-Python3.sh
++
++To activate Omnitrace, source the env file (after activating GPAW venv)::
++
++  source /projappl/project_.../omnitrace-1.10.4-opensuse-15.4-ROCm-50200-PAPI-OMPT-Python3/share/omnitrace/setup-env.sh
++
++
++GPAW for LUMI-C
++===============
++
++First, install required libraries as EasyBuild modules
++(see `LUMI user documentation <https://docs.lumi-supercomputer.eu/software/installing/easybuild/>`_
++for detailed description):
++
++.. code-block:: bash
++
++  # Setup environment
++  # TODO: use correct project_...
++  export EBU_USER_PREFIX=/projappl/project_.../EasyBuild
++  module load LUMI/22.12 partition/C
++  module load cpeGNU/22.12
++  module load EasyBuild-user
++
++  # Install libxc
++  eb libxc-6.2.2-cpeGNU-22.12.eb -r
++
++The above EasyBuild setup is needed only once.
++
++Then, the following steps build GPAW in a Python virtual environment:
++
++.. code-block:: bash
++
++  # Create virtual environment
++  module load cray-python/3.9.13.1
++  python3 -m venv --system-site-packages venv-gpaw-cpu
++
++  # The following will insert environment setup to the beginning of venv/bin/activate
++  # TODO: use correct project_...
++  cp venv-gpaw-cpu/bin/activate venv-gpaw-cpu/bin/activate.old
++  cat << EOF > venv-gpaw-cpu/bin/activate
++  export EBU_USER_PREFIX=/projappl/project_.../EasyBuild
++  export GPAW_SETUP_PATH=/projappl/project_.../gpaw-setups-0.9.20000
++  module load LUMI/22.12 partition/C
++  module load cpeGNU/22.12
++  module load cray-python/3.9.13.1
++  module load cray-fftw/3.3.10.1
++  module load libxc/6.2.2-cpeGNU-22.12  # from EBU_USER_PREFIX
++  EOF
++  cat venv-gpaw-cpu/bin/activate.old >> venv-gpaw-cpu/bin/activate
+ 
+-  git clone git@gitlab.com:gpaw/gpaw
++  # Activate venv
++  source venv-gpaw-cpu/bin/activate
+ 
+-Copy this :git:`~doc/platforms/Cray/siteconfig-lumi-gpu.py` to
+-``gpaw/siteconfig.py`` and compile the C-code and the GPU kernels with::
++  # Install GPAW development version
++  git clone git@gitlab.com:gpaw/gpaw.git
++  export GPAW_CONFIG=$(readlink -f gpaw/doc/platforms/Cray/siteconfig-lumi-cpu.py)
++  cd gpaw
++  rm -rf build _gpaw.*.so gpaw.egg-info
++  pip install -v --log build-cpu.log .
+ 
+-  pip install -v -e gpaw/
++  # Install gpaw setups
++  # TODO: use correct project_...
++  gpaw install-data --no-register /projappl/project_...
+ 
+-Now insert the ``export EBU_USER_PREFIX=...`` line and all the ``module load``
+-lines from above into the start of your ``venv/bin/activate`` script so that
+-the modules are always loaded when you activate your new environment.
++Note that above the siteconfig file is taken from the git clone.
++If you are not using installation through git, use the siteconfig file from here:
++:git:`~doc/platforms/Cray/siteconfig-lumi-cpu.py`.
+ 
+ Interactive jobs can be run like this::
+ 
+-  srun -A project_465000538 -p small-g --nodes=1 --ntasks-per-node=2 --gpus-per-node=1 -t 0:30:00 --pty bash
++  srun -A project_... -p small --nodes=1 --ntasks-per-node=2 -t 0:30:00 --pty bash
+ 
+-To use Omnitrace, source this file???::
++One-liner to run tests::
+ 
+-  source /scratch/project_465000538/GPAW/omnitrace-1.10.2-opensuse-15.4-ROCm-50200-PAPI-OMPT-Python3/share/omnitrace/setup-env.sh
++  for n in 1 2 4 8; do sbatch -p small --nodes=1 --ntasks-per-node=$n -t 04:00:00 -J pytest-cpu-$n -o %x.out --wrap="srun gpaw python -m pytest --pyargs gpaw -v"; done
+ 
+ 
+ Configuring MyQueue
+diff --git a/doc/platforms/Cray/siteconfig-lumi-cpu.py b/doc/platforms/Cray/siteconfig-lumi-cpu.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..eb9d8841bf1bd4c0292680146abb1982201e8e47
+--- /dev/null
++++ b/doc/platforms/Cray/siteconfig-lumi-cpu.py
+@@ -0,0 +1,33 @@
++"""Custom GPAW siteconfig for LUMI-C."""
++
++parallel_python_interpreter = True
++
++mpi = True
++compiler = 'cc'
++compiler_args = []  # remove all default args
++libraries = []
++library_dirs = []
++include_dirs = []
++extra_compile_args = [
++    '-g',
++    '-O3',
++    '-fopenmp',
++    '-fPIC',
++    '-Wall',
++    '-Wno-stringop-overflow',  # suppress warnings from MPI_STATUSES_IGNORE
++    '-Werror',
++    ]
++extra_link_args = ['-fopenmp']
++
++# FFTW
++fftw = True
++libraries += ['fftw3']
++
++# ScaLAPACK
++# Note: required libraries are linked by compiler wrappers
++scalapack = True
++
++# Libxc
++libraries += ['xc']
++
++define_macros += [('GPAW_ASYNC', 1)]
+diff --git a/doc/platforms/Cray/siteconfig-lumi-gpu.py b/doc/platforms/Cray/siteconfig-lumi-gpu.py
+index 2ea30348f26b2bd9ce9e6a1e01297256fc22d044..3236fc0a5dcac2395bbbb2e0cb897d151e2ec24d 100644
+--- a/doc/platforms/Cray/siteconfig-lumi-gpu.py
++++ b/doc/platforms/Cray/siteconfig-lumi-gpu.py
+@@ -1,36 +1,24 @@
+ """Custom GPAW siteconfig for LUMI-G."""
+ 
++parallel_python_interpreter = True
++
+ mpi = True
+ compiler = 'cc'
++compiler_args = []  # remove all default args
+ libraries = []
+ library_dirs = []
+ include_dirs = []
+ extra_compile_args = [
++    '-g',
+     '-O3',
+-    '-march=native',
+-    '-mtune=native',
+-    '-mavx2',
+     '-fopenmp',
+     '-fPIC',
+     '-Wall',
+     '-Wno-stringop-overflow',  # suppress warnings from MPI_STATUSES_IGNORE
+-    '-DNDEBUG',
+-    '-g']
++    '-Werror',
++    ]
+ extra_link_args = ['-fopenmp']
+ 
+-# hip
+-gpu = True
+-gpu_target = 'hip-amd'
+-gpu_compiler = 'hipcc'
+-gpu_include_dirs = []
+-gpu_compile_args = ['--offload-arch=gfx90a', '-O3', '-g']
+-libraries += ['amdhip64', 'hipblas']
+-# define_macros += [('GPAW_GPU_AWARE_MPI', None)]
+-
+-# ELPA
+-elpa = True
+-libraries += ['elpa']
+-
+ # FFTW
+ fftw = True
+ libraries += ['fftw3']
+@@ -43,3 +31,15 @@ scalapack = True
+ libraries += ['xc']
+ 
+ define_macros += [('GPAW_ASYNC', 1)]
++
++# hip
++gpu = True
++gpu_target = 'hip-amd'
++gpu_compiler = 'hipcc'
++gpu_include_dirs = []
++gpu_compile_args = [
++    '-g',
++    '-O3',
++    '--offload-arch=gfx90a',
++    ]
++libraries += ['amdhip64', 'hipblas']
+diff --git a/gpaw/test/lcaotddft/test_molecule.py b/gpaw/test/lcaotddft/test_molecule.py
+index 3735564dc0c8a8fe06ef79a7b93831bee66c3d4a..cf66abf0f4e42ec895df0c1deac9ed19a05afcf4 100644
+--- a/gpaw/test/lcaotddft/test_molecule.py
++++ b/gpaw/test/lcaotddft/test_molecule.py
+@@ -277,7 +277,7 @@ def test_spinpol_dipole_moment(initialize_system, initialize_system_spinpol,
+     # so spin-paired and spin-polarized calculation should give same result
+     check_txt_data(module_tmp_path / 'dm.dat',
+                    module_tmp_path / 'spinpol' / 'dm.dat',
+-                   atol=1e-12)
++                   atol=1.0001e-12)
+ 
+ 
+ @pytest.mark.rttddft
+


### PR DESCRIPTION
This is based on the instruction from @trossi https://gitlab.com/gpaw/gpaw/-/blob/7fa95475d156cbc77bb53332eec7d0a678321576/doc/platforms/Cray/lumi.rst

It also adds CuPy update for LUMI/23.09 with ROCm/5.2.3 and refined ELPA GPU recipe.  

Still some issues remain with the easyconfig:
- [x] OpenMP is now turned off while ELPA does not support it with AMD GPUs (linking GPAW w/OMP against ELPA w/o OMP casuses LibSci version mismatch) 
- [x] It installs ASE as a Python module without an independent easyconfig for it
- [x] It also downloads gpaw-setups which comes as a separate easyconfig in the [easybuilders](https://github.com/easybuilders) repo 
- [x] No virtualenv is used