### PR TITLE
AdaptiveCpp update to release 24.06, target at LUMI/24.03

### DIFF
--- a/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-24.06.0-cpeAMD-23.09-rocm-5.4.3.eb
+++ b/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-24.06.0-cpeAMD-23.09-rocm-5.4.3.eb
@@ -1,0 +1,81 @@
+easyblock = 'CMakeMake'
+
+name =    'AdaptiveCpp'
+version = '24.06.0'
+versionsuffix = '-rocm-5.4.3'
+
+homepage = 'https://adaptivecpp.github.io/'
+
+whatis = [
+    "Description: Implementation of SYCL and C++ standard parallelism for CPUs and GPUs from all vendors: The independent, community-driven compiler for C++-based heterogeneous programming models."
+]
+
+description = """
+AdaptiveCpp is the independent, community-driven modern platform for C++-based heterogeneous programming models targeting CPUs and GPUs from all major vendors. 
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '23.09'}
+toolchainopts = {'verbose': False, 'openmp': True}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/AdaptiveCpp',
+        'repo_name': '%(name)s',
+        'commit': 'v%(version)s',
+    }
+}]
+
+dependencies = [
+    ('amd/5.4.3', EXTERNAL_MODULE),
+    ('rocm/5.4.3', EXTERNAL_MODULE),
+    ('gcc-mixed/12.2.0', EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('Boost', '1.82.0'),
+]
+
+preconfigopts  = 'export PATH=${ROCM_PATH}/llvm/bin:$PATH && '
+preconfigopts += 'export C_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+preconfigopts += 'export CPLUS_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+preconfigopts += 'export LIBRARY_PATH=${EBROOTBOOST}/lib:${EBROOTBUILDTOOLS}/lib:${ROCM_PATH}/lib && '
+
+configopts  = '-DACPP_VERSION_SUFFIX={} '.format(versionsuffix)
+configopts += '-DROCM_PATH=$ROCM_PATH '
+configopts += '-DCMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/clang '
+configopts += '-DCMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/clang++ '
+configopts += '-DWITH_ACCELERATED_CPU=ON '
+configopts += '-DWITH_CPU_BACKEND=ON '
+configopts += '-DWITH_CUDA_BACKEND=OFF '
+configopts += '-DWITH_ROCM_BACKEND=ON '
+configopts += '-DWITH_OPENCL_BACKEND=OFF '
+configopts += '-DWITH_LEVEL_ZERO_BACKEND=OFF '
+configopts += '-DACPP_TARGETS="gfx90a" '
+configopts += '-DBoost_NO_BOOST_CMAKE=TRUE '
+configopts += '-DBoost_NO_SYSTEM_PATHS=TRUE '
+configopts += '-DWITH_SSCP_COMPILER=OFF ' 
+configopts += '-DROCM_CXX_FLAGS="--gcc-toolchain=$GCC_PATH/snos/" '
+configopts += '-DLLVM_DIR=${ROCM_PATH}/llvm/lib/cmake/llvm/ '
+configopts += '-DHIPSYCL_ALLOW_INSTANT_SUBMISSION=1 '
+
+
+sanity_check_paths = {
+    'files': ['bin/acpp', 'include/AdaptiveCpp/sycl/sycl.hpp',
+              'lib/hipSYCL/librt-backend-omp.%s' % SHLIB_EXT,
+              'lib/hipSYCL/librt-backend-hip.%s' % SHLIB_EXT,
+              'lib/libacpp-clang.%s' % SHLIB_EXT,
+              'lib/libacpp-rt.%s' % SHLIB_EXT],
+    'dirs': ['include/AdaptiveCpp/CL', 'include/AdaptiveCpp/SYCL'],
+}
+sanity_check_commands = [
+    'acpp --help'
+]
+
+modextravars = {
+    'ACPP_TARGETS': 'hip:gfx90a',
+}
+
+moduleclass = 'compiler'
+

--- a/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-24.06.0-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-24.06.0-cpeAMD-24.03.eb
@@ -1,0 +1,78 @@
+easyblock = 'CMakeMake'
+
+name =    'AdaptiveCpp'
+version = '24.06.0'
+
+homepage = 'https://adaptivecpp.github.io/'
+
+whatis = [
+    "Description: Implementation of SYCL and C++ standard parallelism for CPUs and GPUs from all vendors: The independent, community-driven compiler for C++-based heterogeneous programming models."
+]
+
+description = """
+AdaptiveCpp is the independent, community-driven modern platform for C++-based heterogeneous programming models targeting CPUs and GPUs from all major vendors. 
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'verbose': False, 'openmp': True}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/AdaptiveCpp',
+        'repo_name': '%(name)s',
+        'commit': 'v%(version)s',
+    }
+}]
+
+dependencies = [
+    ('amd/6.0.3', EXTERNAL_MODULE),
+    ('rocm/6.0.3', EXTERNAL_MODULE),
+    ('gcc-native-mixed/13.2', EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('Boost', '1.83.0'),
+]
+
+preconfigopts  = 'export PATH=${ROCM_PATH}/llvm/bin:$PATH && '
+preconfigopts += 'export C_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+preconfigopts += 'export CPLUS_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
+
+configopts  = '-DACPP_VERSION_SUFFIX="rocm6" '
+configopts += '-DROCM_PATH=$ROCM_PATH '
+configopts += '-DCMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/clang '
+configopts += '-DCMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/clang++ '
+configopts += '-DWITH_ACCELERATED_CPU=ON '
+configopts += '-DWITH_CPU_BACKEND=ON '
+configopts += '-DWITH_CUDA_BACKEND=OFF '
+configopts += '-DWITH_ROCM_BACKEND=ON '
+configopts += '-DWITH_OPENCL_BACKEND=OFF '
+configopts += '-DWITH_LEVEL_ZERO_BACKEND=OFF '
+configopts += '-DACPP_TARGETS="gfx90a" '
+configopts += '-DBoost_NO_BOOST_CMAKE=TRUE '
+configopts += '-DBoost_NO_SYSTEM_PATHS=TRUE '
+configopts += '-DWITH_SSCP_COMPILER=OFF ' 
+configopts += '-DLLVM_DIR=${ROCM_PATH}/llvm/lib/cmake/llvm/ '
+configopts += '-DHIPSYCL_ALLOW_INSTANT_SUBMISSION=1 '
+
+
+sanity_check_paths = {
+    'files': ['bin/acpp', 'include/AdaptiveCpp/sycl/sycl.hpp',
+              'lib/hipSYCL/librt-backend-omp.%s' % SHLIB_EXT,
+              'lib/hipSYCL/librt-backend-hip.%s' % SHLIB_EXT,
+              'lib/libacpp-clang.%s' % SHLIB_EXT,
+              'lib/libacpp-rt.%s' % SHLIB_EXT],
+    'dirs': ['include/AdaptiveCpp/CL', 'include/AdaptiveCpp/SYCL'],
+}
+sanity_check_commands = [
+    'acpp --help'
+]
+
+modextravars = {
+    'ACPP_TARGETS': 'hip:gfx90a',
+}
+
+moduleclass = 'compiler'
+


### PR DESCRIPTION
To be tested against new software stack release after the big system update.