### PR TITLE
Score-P for CPE 24.03

### DIFF
--- a/easybuild/easyconfigs/s/Score-P/README.md
+++ b/easybuild/easyconfigs/s/Score-P/README.md
@@ -35,4 +35,9 @@ Score-P offers the user a maximum of convenience by supporting a number of analy
     as otherwise `roctracer` is not correctly detected. The `rocm` module does a few
     initialisations of environment variables that the `amd` module does not do.
     
- 
+ ### Version 8.4 for CPE 24.03
+
+-   Conversion of the easyconfigs for 23.09 with some build dependencies moved
+    to runtime dependencies as we don't want to rely on RPATH.
+
+-   The AOCC version is not provided: some tests fail.

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAMD-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAMD-24.03-rocm.eb
@@ -1,0 +1,100 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.8'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+patches =     ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter somehow is not provided if amd/5.2.3 is used.
+    ('rocm',            EXTERNAL_MODULE),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+# The "make installcheck" fails OPARI2 is used with Cray compiler wrappers and a GPU target module
+# loaded, as some incompatible order of include files is used in those cases. Yet we want to
+# do whatever testing possible so we unload the craype-accel module (as this disabled the automatic
+# enablement of GPU offload).
+postinstallcmds = ['module unload craype-accel-amd-gfx90a && make installcheck V=1 VERBOSE=1']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03-rocm.eb
@@ -1,0 +1,103 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+#DOC This version has the HIP adapter and is the recommended cpeCray version for LUMI-G.
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.8'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter
+    ('rocm',            EXTERNAL_MODULE),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+configopts += '--with-rocm=$ROCM_PATH '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+# The "make installcheck" fails OPARI2 is used with Cray compiler wrappers and a GPU target module
+# loaded, as some incompatible order of include files is used in those cases. Yet we want to
+# do whatever testing possible so we unload the craype-accel module (as this disabled the automatic
+# enablement of GPU offload).
+postinstallcmds = [
+    'module unload craype-accel-amd-gfx90a && make installcheck V=1 VERBOSE=1',
+]
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
@@ -1,0 +1,93 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+#DOC Score-P without the HIP-adapter for the regular compute nodes.
+#DOC The build process takes a while (up to 1 hour) due to lengthy configure and postprocessing steps.
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.8'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Score-P'
+version = local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('CubeLib',    local_CubeLib_version),
+    ('CubeWriter', local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',  local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
@@ -56,13 +56,14 @@ checksums = [
 ]
 
 builddependencies = [
-    ('CubeLib',    local_CubeLib_version),
-    ('CubeWriter', local_CubeWriter_version),
-    # Unwinding/sampling support (optional):
-    ('libunwind',  local_libunwind_version),
+    ('buildtools', '%(toolchain_version)s', '', True),
 ]
 
 dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
     ('OPARI2',          local_OPARI2_version),
     ('OTF2',            local_OTF2_version),
     # Support for SHMEM

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-24.03.eb
@@ -1,0 +1,93 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+#DOC Score-P without the HIP-adapter for the regular compute nodes.
+#DOC The build process takes a while (up to 1 hour) due to lengthy configure and postprocessing steps.
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.8'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Score-P'
+version = local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+checksums = [
+    '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+]
+
+builddependencies = [
+    ('CubeLib',    local_CubeLib_version),
+    ('CubeWriter', local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',  local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Make OMPT default, if available
+configopts += '--enable-default=ompt '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeGNU-24.03.eb
@@ -56,13 +56,14 @@ checksums = [
 ]
 
 builddependencies = [
-    ('CubeLib',    local_CubeLib_version),
-    ('CubeWriter', local_CubeWriter_version),
-    # Unwinding/sampling support (optional):
-    ('libunwind',  local_libunwind_version),
+    ('buildtools', '%(toolchain_version)s', '', True),
 ]
 
 dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
     ('OPARI2',          local_OPARI2_version),
     ('OTF2',            local_OTF2_version),
     # Support for SHMEM


### PR DESCRIPTION
This PR includes the easyconfigs for CPE 24.03. 

The cpeAOCC version is not included yet because the `make installcheck` fails. The cause of the failure is that some instrumentation that the test expects to be present is not present.