### PR TITLE
{perf}[LUMI/24.03] Changes to JSC tools

### DIFF
--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAMD-24.03.eb
@@ -14,6 +14,7 @@
 easyblock = 'EB_Score_minus_P_minus_CPE'
 
 local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
 
 name =    'OTF2'
 version = local_OTF2_version
@@ -43,6 +44,7 @@ builddependencies = [
     ('buildtools',         '%(toolchain_version)s', '', True),
     ('craype-network-none', EXTERNAL_MODULE),
     ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
 ]
 
 preconfigopts = 'module unload rocm xpmem && '
@@ -50,11 +52,15 @@ prebuildopts = preconfigopts
 
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               ('lib/libotf2.a', 'lib64/libotf2.a'),
               ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
     'dirs': [],
 }
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeAOCC-24.03.eb
@@ -14,6 +14,7 @@
 easyblock = 'EB_Score_minus_P_minus_CPE'
 
 local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
 
 name =    'OTF2'
 version = local_OTF2_version
@@ -43,6 +44,7 @@ builddependencies = [
     ('buildtools',         '%(toolchain_version)s', '', True),
     ('craype-network-none', EXTERNAL_MODULE),
     ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
 ]
 
 preconfigopts = 'module unload rocm xpmem && '
@@ -50,11 +52,15 @@ prebuildopts = preconfigopts
 
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               ('lib/libotf2.a', 'lib64/libotf2.a'),
               ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
     'dirs': [],
 }
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeCray-24.03.eb
@@ -14,6 +14,7 @@
 easyblock = 'EB_Score_minus_P_minus_CPE'
 
 local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
 
 name =    'OTF2'
 version = local_OTF2_version
@@ -43,6 +44,7 @@ builddependencies = [
     ('buildtools',         '%(toolchain_version)s', '', True),
     ('craype-network-none', EXTERNAL_MODULE),
     ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
 ]
 
 preconfigopts = 'module unload rocm xpmem && '
@@ -50,11 +52,15 @@ prebuildopts = preconfigopts
 
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               ('lib/libotf2.a', 'lib64/libotf2.a'),
               ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
     'dirs': [],
 }
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.0.3-cpeGNU-24.03.eb
@@ -14,6 +14,7 @@
 easyblock = 'EB_Score_minus_P_minus_CPE'
 
 local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
 
 name =    'OTF2'
 version = local_OTF2_version
@@ -43,6 +44,7 @@ builddependencies = [
     ('buildtools',         '%(toolchain_version)s', '', True),
     ('craype-network-none', EXTERNAL_MODULE),
     ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
 ]
 
 preconfigopts = 'module unload rocm xpmem && '
@@ -50,11 +52,15 @@ prebuildopts = preconfigopts
 
 configopts = '--enable-shared'
 
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
 sanity_check_paths = {
     'files': ['bin/otf2-config', 'include/otf2/otf2.h',
               ('lib/libotf2.a', 'lib64/libotf2.a'),
               ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
     'dirs': [],
 }
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/README.md
+++ b/easybuild/easyconfigs/o/OTF2/README.md
@@ -27,3 +27,8 @@ it will avoid copying during unification of parallel event streams.
 -   EasyConfig prepared by Jan André Reuter of JSC based on the EasyConfigs in use at JSC.
 
     Compilation is done via the custom EasyBlock for Score-P.
+
+### Version 3.0.3 for CPE 24.03
+
+-   Reuse of EasyConfigs of CPE 23.09 with the inclusion of Python to build the Python bindings.
+

--- a/easybuild/easyconfigs/s/Scalasca/README.md
+++ b/easybuild/easyconfigs/s/Scalasca/README.md
@@ -14,7 +14,11 @@ parallel programs
 -   [Scalasca support in the JSC repository](https://github.com/easybuilders/JSC/tree/2024/Golden_Repo/s/Scalasca)
 
 
-### Version 2.6 for CPE 23.09
+### Version 2.6.1 for CPE 23.09
 
 -   The EasyConfig was contributed by Jan André Reuter of JSC and based on their
     EasyConfigs.
+
+### Version 2.6.1 for CPE 24.03
+
+-   Reuse of EasyConfig for CPE 23.09.

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAMD-24.03.eb
@@ -1,0 +1,90 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.1'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+local_Scalasca_maj_min = '.'.join( local_Scalasca_version.split('.')[:2] )
+
+docurls = [
+    f'PDF manual at https://apps.fz-juelich.de/scalasca/releases/scalasca/{local_Scalasca_maj_min}/docs/UserGuide.pdf',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources =     [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+} 
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH':         'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeAOCC-24.03.eb
@@ -1,0 +1,97 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.1'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+local_Scalasca_maj_min = '.'.join( local_Scalasca_version.split('.')[:2] )
+
+docurls = [
+    f'PDF manual at https://apps.fz-juelich.de/scalasca/releases/scalasca/{local_Scalasca_maj_min}/docs/UserGuide.pdf',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/project:/flash'
+}
+
+modluafooter = f"""
+LmodMessage( 'Scalasca also requires a suitable version of Score-P to be loaded, ' ..
+             'which is not done by this module as there might be multiple suitable versions, ' ..
+             'especially to support the multiple versions of ROCm that we sometimes offer. '..
+             'This version was tested with Score-P {local_ScoreP_version}.' )
+"""
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeCray-24.03.eb
@@ -1,0 +1,97 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.1'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+local_Scalasca_maj_min = '.'.join( local_Scalasca_version.split('.')[:2] )
+
+docurls = [
+    f'PDF manual at https://apps.fz-juelich.de/scalasca/releases/scalasca/{local_Scalasca_maj_min}/docs/UserGuide.pdf',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/project:/flash'
+}
+
+modluafooter = f"""
+LmodMessage( 'Scalasca also requires a suitable version of Score-P to be loaded, ' ..
+             'which is not done by this module as there might be multiple suitable versions, ' ..
+             'especially to support the multiple versions of ROCm that we sometimes offer. '..
+             'This version was tested with Score-P {local_ScoreP_version}.' )
+"""
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.1-cpeGNU-24.03.eb
@@ -1,0 +1,97 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.1'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.8.2'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.0.3'         # https://www.vi-hps.org/projects/score-p/
+local_ScoreP_version =       '8.4'           # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+local_Scalasca_maj_min = '.'.join( local_Scalasca_version.split('.')[:2] )
+
+docurls = [
+    f'PDF manual at https://apps.fz-juelich.de/scalasca/releases/scalasca/{local_Scalasca_maj_min}/docs/UserGuide.pdf',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'Scalasca-2.6.1_nowarn_omp_pragmas.patch',
+]
+checksums = [
+    'a0dbc3de82a6c0fe598de9e340513cff2882c199410a632d3a7f073ba921c7e7',  # scalasca-2.6.1.tar.gz
+    '53fd1305f75b7552208ff5375d0d754eb97d3eec45f67e506e9b55d2b16361ac',  # Scalasca-2.6.1_nowarn_omp_pragmas.patch
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/backend/libpearl.replay.a', 'lib64/backend/libpearl.replay.a')],
+    'dirs': [],
+}
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+    'PATH': 'bin/backend'
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/project:/flash'
+}
+
+modluafooter = f"""
+LmodMessage( 'Scalasca also requires a suitable version of Score-P to be loaded, ' ..
+             'which is not done by this module as there might be multiple suitable versions, ' ..
+             'especially to support the multiple versions of ROCm that we sometimes offer. '..
+             'This version was tested with Score-P {local_ScoreP_version}.' )
+"""
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/README.md
+++ b/easybuild/easyconfigs/s/Score-P/README.md
@@ -40,4 +40,3 @@ Score-P offers the user a maximum of convenience by supporting a number of analy
 -   Conversion of the easyconfigs for 23.09 with some build dependencies moved
     to runtime dependencies as we don't want to rely on RPATH.
 
--   The AOCC version is not provided: some tests fail.

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAMD-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAMD-24.03-rocm.eb
@@ -69,11 +69,11 @@ dependencies = [
     ('libbfd',          local_libbfd_version),
     # Hardware counter support (optional):
     ('papi',            EXTERNAL_MODULE),
-    # Support for HIP adapter somehow is not provided if amd/5.2.3 is used.
+    # Support for HIP adapter.
     ('rocm',            EXTERNAL_MODULE),
 ]
 
-configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeAMD-24.03-rocm '
 configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
 configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
 # Add CFLAGS to prevent error of roctracer check due to path issues

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeAOCC-24.03.eb
@@ -44,46 +44,43 @@ docurls = [
     'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
 ]
 
-toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
 toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
 
 source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
 sources = ['scorep-%(version)s.tar.gz']
-patches = ['Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch']
+patches = [
+    'Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch',
+    'Score-P-8.4-installcheck-prevent-memory-optimization.patch'
+]
 checksums = [
     '7bbde9a0721d27cc6205baf13c1626833bcfbabb1f33b325a2d67976290f7f8a',  # scorep-8.4.tar.gz
-    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d'   # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+    '5ad42c8c21334c55feb7fb7e25461ef91f063b2c49b33ed3fc0ea3b5ce109e8d',  # Score-P-8.4-fix-mpi-dependency-Cray-ldflags.patch
+    '7c0306046b234b5523c613d9de1989e716bfb8bec7877db553479ebeee6d907d'   # Score-P-8.4-installcheck-prevent-memory-optimization.patch
 ]
 
 builddependencies = [
-    ('buildtools', '%(toolchain_version)s', '', True),
+    ('CubeLib',    local_CubeLib_version),
+    ('CubeWriter', local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',  local_libunwind_version),
 ]
 
 dependencies = [
-    ('CubeLib',         local_CubeLib_version),
-    ('CubeWriter',      local_CubeWriter_version),
     ('OPARI2',          local_OPARI2_version),
     ('OTF2',            local_OTF2_version),
-    ('libbfd',          local_libbfd_version),
-    # Unwinding/sampling support (optional):
-    ('libunwind',       local_libunwind_version),
-    ('CubeLib',         local_CubeLib_version),
-    ('CubeWriter',      local_CubeWriter_version),
-    # Unwinding/sampling support (optional):
-    ('libunwind',       local_libunwind_version),
     # Support for SHMEM
     ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
     # Hardware counter support (optional):
     ('papi',            EXTERNAL_MODULE),
 ]
 
-configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeGNU-24.03 '
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeAOCC-24.03 '
 configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
 configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
 # Make OMPT default, if available
 configopts += '--enable-default=ompt '
-# Force set correct GCC compilers, as Score-P will use /usr/bin/gcc otherwise
-configopts += 'CC=gcc-13 CXX=g++-13 F77=gfortran-13 FC=gfortran-13 '
 
 postinstallcmds = ['make installcheck']
 

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03-rocm.eb
@@ -75,7 +75,7 @@ dependencies = [
     ('rocm',            EXTERNAL_MODULE),
 ]
 
-configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-24.03-rocm '
 configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
 configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
 configopts += '--with-rocm=$ROCM_PATH '

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-cpeCray-24.03.eb
@@ -73,7 +73,7 @@ dependencies = [
     ('papi',            EXTERNAL_MODULE),
 ]
 
-configopts  = '--enable-shared --disable-static --with-machine-name=LUMI '
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-24.03 '
 configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
 configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
 # Make OMPT default, if available

--- a/easybuild/easyconfigs/s/Score-P/Score-P-8.4-installcheck-prevent-memory-optimization.patch
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-8.4-installcheck-prevent-memory-optimization.patch
@@ -1,0 +1,31 @@
+Prevent optimization via `-O0` for the memory instrumentation check
+as AOCC 4.1.0 and newer removes all the allocation calls otherwise,
+causing the check to fail.
+
+diff --git a/test/instrumenter_checks/memory/Makefile.in b/test/instrumenter_checks/memory/Makefile.in
+index 4f1e0c385a73f2653c19fff6cb297a6ad4e80b28..520a9b7ef5a5427533649ce5179a230dbeb65bea 100644
+--- a/test/instrumenter_checks/memory/Makefile.in
++++ b/test/instrumenter_checks/memory/Makefile.in
+@@ -5,7 +5,7 @@
+ ##
+ ## This file is part of the Score-P software (http://www.score-p.org)
+ ##
+-## Copyright (c) 2014,
++## Copyright (c) 2014, 2024,
+ ## Forschungszentrum Juelich GmbH, Germany
+ ##
+ ## Copyright (c) 2016,
+@@ -18,10 +18,10 @@
+ 
+ 
+ CC       = @CC@
+-CFLAGS   =
++CFLAGS   = -O0
+ 
+ CXX      = @CXX@
+-CXXFLAGS =
++CXXFLAGS = -O0
+ 
+ TOOLS_BINDIR               = @BINDIR@
+ INSTRUMENTERCHECK_SRCDIR   = @abs_top_srcdir@/../test/instrumenter_checks
+


### PR DESCRIPTION
Heya,

first of all, thanks a lot for continuing to update the EasyConfigs I've provided a while back.
I've did some testing of the latest CPE/24.03 after the upgrade was finished and want to provide a few updates to the Score-P, OTF2 and Scalasca modules to bring them up-to-date with fixes and changes done upstream.

The PR includes the following changes:

- OTF2: Build Python bindings using the toolchain Python. See upstream PR https://github.com/easybuilders/easybuild-easyconfigs/pull/21325
- Score-P: Fix the installcheck failing for AOCC and do some smaller updates to indicate which toolchain was used.
- Scalasca: Just update the module for the new toolchain.

----

I've tested all these modules by installing them via EasyBuild on `partition/C`, `partition/L` and `partition/G`. The workaround for `cpeCray-24.03-rocm` is still required. We are working on a fix for this, targeting Cray environments 23.12 and higher. A MR for the fix is open internally, but needs a lot more testing first.