### PR TITLE
Fix PETSc multiple LibSci linking

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeCray-24.03-rocm.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeCray-24.03-rocm.eb
@@ -1,0 +1,93 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+# GPU version adapted for LUMI
+easyblock = 'ConfigureMake'
+
+local_ELPA_version = '2024.05.001'
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-rocm'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'usempi': True, 'openmp': False}
+
+source_urls = ['https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/%(version)s/']
+sources =  ['elpa-%(version)s.tar.gz']
+checksums = ['9caf41a3e600e2f6f4ce1931bd54185179dade9c171556d0c9b41bbc6940f2f6']
+
+patches = [
+   'elpa-2024.05.001-cray-ftn.patch',
+]
+
+builddependencies = [ 
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('rocm',        EXTERNAL_MODULE),
+]
+
+configopts = ' '.join([
+    'CPP=cpp CC=cc CXX=hipcc FC=ftn',
+    'CFLAGS="-g $CFLAGS"',
+    'FCFLAGS="-g $FCFLAGS"',
+    'CXXFLAGS="-g --offload-arch=gfx90a -std=c++17 -I$ROCM_PATH/include/hip -I$ROCM_PATH/include/ -I$ROCM_PATH/include/rocsolver -I$CRAY_MPICH_DIR/include"',
+    '--enable-static',
+    '--disable-generic',
+    '--disable-sse',
+    '--disable-avx',
+    '--enable-avx2',
+    '--disable-avx512',
+    '--enable-amd-gpu-kernels',
+    '--with-AMD-gpu-support-only',
+    '--enable-gpu-streams=amd',
+    '--enable-hipcub',
+    '--enable-single-precision ',
+    '--disable-openmp',
+    '--with-mpi=yes',
+    '--enable-cuda-aware-mpi',
+    '--enable-rocsolver',
+])
+
+prebuildopts = 'export CPATH=$ROCM_PATH/include/hipblas && make clean && '
+
+maxparallel = 16
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules',]
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s',
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeCray-24.03-rocm.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeCray-24.03-rocm.eb
@@ -69,7 +69,7 @@ configopts = ' '.join([
     '--disable-openmp',
     '--with-mpi=yes',
     '--enable-cuda-aware-mpi',
-    '--enable-rocsolver',
+    '--with-rocsolver',
 ])
 
 prebuildopts = 'export CPATH=$ROCM_PATH/include/hipblas && make clean && '

--- a/easybuild/easyconfigs/e/ELPA/elpa-2024.05.001-cray-ftn.patch
+++ b/easybuild/easyconfigs/e/ELPA/elpa-2024.05.001-cray-ftn.patch
@@ -1,0 +1,70 @@
+diff --git a/src/GPU/ROCm/elpa_explicit_name_amd_gpu.cpp b/src/GPU/ROCm/elpa_explicit_name_amd_gpu.cpp
+index 2e495f4d..6488be92 100644
+--- a/src/GPU/ROCm/elpa_explicit_name_amd_gpu.cpp
++++ b/src/GPU/ROCm/elpa_explicit_name_amd_gpu.cpp
+@@ -48,6 +48,7 @@
+ 
+ #include <cstdio>
+ #include <hip/hip_runtime.h>
++#include "config-f90.h"
+ 
+ extern "C" {
+   
+diff --git a/src/cholesky/elpa_cholesky_template.F90 b/src/cholesky/elpa_cholesky_template.F90
+index ba6d4939..2627e90a 100644
+--- a/src/cholesky/elpa_cholesky_template.F90
++++ b/src/cholesky/elpa_cholesky_template.F90
+@@ -339,13 +339,13 @@
+ 
+   if (useGPU) then
+ #if defined(WITH_NVIDIA_CUSOLVER) || defined(WITH_AMD_ROCSOLVER)    
+-    successGPU = gpu_malloc(info_dev, 1*sizeof(c_int))
++    successGPU = gpu_malloc(info_dev, int(1*sizeof(c_int), kind=c_intptr_t))
+     check_alloc_gpu("elpa_cholesky: info_dev", successGPU)
+ 
+-    successGPU = gpu_malloc(info_abs_accumulated_dev, 1*sizeof(c_int))
++    successGPU = gpu_malloc(info_abs_accumulated_dev, int(1*sizeof(c_int), kind=c_intptr_t))
+     check_alloc_gpu("elpa_cholesky: info_abs_accumulated_dev", successGPU)
+     
+-    successGPU = gpu_memset(info_abs_accumulated_dev, 0, 1*sizeof(c_int))
++    successGPU = gpu_memset(info_abs_accumulated_dev, 0, int(1*sizeof(c_int), kind=c_intptr_t))
+     check_memcpy_gpu("elpa_cholesky: memset info_abs_accumulated_dev", successGPU)
+ #endif
+ 
+diff --git a/src/elpa_impl_math_template.F90 b/src/elpa_impl_math_template.F90
+index b96f2197..0dbc749d 100644
+--- a/src/elpa_impl_math_template.F90
++++ b/src/elpa_impl_math_template.F90
+@@ -1184,21 +1184,20 @@
+ 
+     subroutine elpa_solve_tridiagonal_&
+                     &ELPA_IMPL_SUFFIX&
+-                    &_c(handle, d_p, e_p, q_p, error) &
+ #ifdef REALCASE
+ #ifdef DOUBLE_PRECISION_REAL
+-                    bind(C, name="elpa_solve_tridiagonal_d")
++                    &_c(handle, d_p, e_p, q_p, error) bind(C, name="elpa_solve_tridiagonal_d")
+ #endif
+ #ifdef SINGLE_PRECISION_REAL
+-                    bind(C, name="elpa_solve_tridiagonal_f")
++                    &_c(handle, d_p, e_p, q_p, error) bind(C, name="elpa_solve_tridiagonal_f")
+ #endif
+ #endif
+ #ifdef COMPLEXCASE
+ #ifdef DOUBLE_PRECISION_COMPLEX
+-                    & !bind(C, name="elpa_solve_tridiagonal_dc")
++                    &_c(handle, d_p, e_p, q_p, error) !bind(C, name="elpa_solve_tridiagonal_dc")
+ #endif
+ #ifdef SINGLE_PRECISION_COMPLEX
+-                    & !bind(C, name="elpa_solve_tridiagonal_fc")
++                    &_c(handle, d_p, e_p, q_p, error) !bind(C, name="elpa_solve_tridiagonal_fc")
+ #endif
+ #endif
+ 
+@@ -1220,4 +1219,4 @@
+               &ELPA_IMPL_SUFFIX&
+               & (self, d, e, q, error)
+     end subroutine
+-    
+\ No newline at end of file
++    

--- a/easybuild/easyconfigs/m/MUMPS/MUMPS-5.6.1-cpeGNU-24.03-OpenMP.eb
+++ b/easybuild/easyconfigs/m/MUMPS/MUMPS-5.6.1-cpeGNU-24.03-OpenMP.eb
@@ -1,0 +1,55 @@
+
+local_SCOTCH_version = '7.0.4'
+local_METIS_version  = '5.1.0'
+
+name = 'MUMPS'
+version = '5.6.1'
+versionsuffix = '-OpenMP'
+
+homepage = 'https://graal.ens-lyon.fr/MUMPS/'
+
+whatis = [
+    'Description: A parallel sparse direct solver',
+]
+
+description = """
+MUMPS stands for MUltifrontal Massively Parallel sparse direct Solver.
+
+Both static and shared libraries are provided.
+"""
+
+docurls = [
+    'User guide downloadable from https://mumps-solver.org/index.php?page=doc'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True, 'gfortran9-compat': True}
+
+source_urls = ['http://mumps-solver.org/']
+sources = ['%(name)s_%(version)s.tar.gz']
+
+patches = [
+    '%(name)s-%(version)s_shared-pord.patch',  # builds the shared libs of PORD
+    '%(name)s-%(version)s_shared-mumps.patch', # builds shared libs of MUMPS
+]
+
+checksums = [
+    {'MUMPS_%(version)s.tar.gz'             : '1920426d543e34d377604070fde93b8d102aa38ebdf53300cbce9e15f92e2896'},
+    {'MUMPS-%(version)s_shared-pord.patch'  : '51d3685208a42581b462592eea977f185d87e871fb65e8e90a54dd2ad18ac715'},
+    {'MUMPS-%(version)s_shared-mumps.patch' : '4b02322593542d3c2254c72af5df10907eab565576d36839ed40c8da44e162bc'},
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('SCOTCH', local_SCOTCH_version),
+    ('METIS',  local_METIS_version),
+]
+
+parallel = 1
+
+buildopts = 'all SONAME_VERSION="%(version)s"'
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
@@ -44,7 +44,7 @@ dependencies = [
     ('METIS',              local_METIS_version),
     ('ParMETIS',           local_ParMETIS_version),
     ('SCOTCH',             local_SCOTCH_version),
-    ('MUMPS',              local_MUMPS_version),
+    ('MUMPS',              local_MUMPS_version, '-OpenMP'),
     ('Hypre',              local_Hypre_version),
     ('SuperLU',            local_SuperLU_version, '-OpenMP'),
     ('SuperLU_DIST',       local_SuperLU_DIST_version, '-OpenMP'),

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03.eb
@@ -44,7 +44,7 @@ dependencies = [
     ('METIS',              local_METIS_version),
     ('ParMETIS',           local_ParMETIS_version),
     ('SCOTCH',             local_SCOTCH_version),
-    ('MUMPS',              local_MUMPS_version),
+    ('MUMPS',              local_MUMPS_version, '-OpenMP'),
     ('Hypre',              local_Hypre_version),
     ('SuperLU',            local_SuperLU_version, '-OpenMP'),
     ('SuperLU_DIST',       local_SuperLU_DIST_version, '-OpenMP'),


### PR DESCRIPTION
This is to fix PETSc linking with both LibSci and LibSciMP because of wrong MUMPS configuration. 