### PR TITLE
CXI library version SHS 12.0.1

### DIFF
--- a/easybuild/easyconfigs/f/FUSE/FUSE-2.99.eb
+++ b/easybuild/easyconfigs/f/FUSE/FUSE-2.99.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'FUSE'
+version = '2.9.9'
+
+homepage = 'https://github.com/libfuse/libfuse'
+description = "The reference implementation of the Linux FUSE (Filesystem in Userspace) interface"
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/libfuse/libfuse/releases/download/fuse-%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+
+configopts  = 'MOUNT_FUSE_PATH=%(installdir)s/sbin '
+configopts += 'UDEV_RULES_PATH=%(installdir)s/etc '
+configopts += 'INIT_D_PATH=%(installdir)s/etc '
+
+sanity_check_paths = {
+    'files': ['lib64/libfuse.%s' % SHLIB_EXT,
+              'lib64/pkgconfig/fuse.pc'],
+    'dirs': ['include/fuse'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libconfig/libconfig-1.7.3.eb
+++ b/easybuild/easyconfigs/l/libconfig/libconfig-1.7.3.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'libconfig'
+version = '1.7.3'
+
+homepage = 'https://hyperrealm.github.io/libconfig'
+description = "Libconfig is a simple library for processing structured configuration files"
+
+toolchain = SYSTEM
+
+source_urls = ['https://hyperrealm.github.io/libconfig/dist/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['545166d6cac037744381d1e9cc5a5405094e7bfad16a411699bcff40bbb31ee7']
+
+sanity_check_paths = {
+    'files': ['include/libconfig.h', 'include/libconfig.h++', 'lib/libconfig.a', 'lib/libconfig++.a',
+              'lib/libconfig.%s' % SHLIB_EXT, 'lib/libconfig++.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libcxi/libcxi-0f3609b.eb
+++ b/easybuild/easyconfigs/l/libcxi/libcxi-0f3609b.eb
@@ -1,0 +1,57 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcxi'
+version = '0f3609b'
+
+homepage = 'https://github.com/HewlettPackard/shs-libcxi'
+description = "The CXI library provides interfaces which interact directly with CXI drivers. CXI drivers support communication over the Cray Cassini NIC."
+
+toolchain = SYSTEM
+
+sources = [
+    {
+        'filename': '%(name)s.tar.gz',
+        'git_config': {
+            'url': 'https://github.com/HewlettPackard',
+            'repo_name': 'shs-libcxi',
+            'commit': '0f3609b5e224636abffc7ceffe6f4e9c83244c08'
+        },
+     },
+    {
+        'filename': 'cassini-headers.tar.gz',
+        'git_config': {
+            'url': 'https://github.com/HewlettPackard',
+            'repo_name': 'shs-cassini-headers',
+            'commit': '9a8a738a879f007849fbc69be8e3487a4abf0952',
+            'clone_into': '../cassini-headers/install'
+        },
+     },
+    {
+        'filename': 'cxi-driver.tar.gz',
+        'git_config': {
+            'url': 'https://github.com/HewlettPackard',
+            'repo_name': 'shs-cxi-driver',
+            'commit': '751ebc4263827e2b47e3b2b89aa6f37824824ff2',
+            'clone_into': '../cxi-driver'
+        },
+     },
+]
+
+builddependencies = [
+    ('rocm', EXTERNAL_MODULE),
+    ('libconfig', '1.7.3', '', SYSTEM),
+    ('libuv', '1.48.0', '', SYSTEM),
+    ('lm-sensors', '3.6.0', '', SYSTEM),
+    ('FUSE', '2.9.9', '', SYSTEM),
+]
+
+preconfigopts  = './autogen.sh && '
+configopts = 'CFLAGS="-Wno-error -D_FILE_OFFSET_BITS=64 -I../cxi-driver/include" --with-udevrulesdir=%(installdir)s/lib/udev/rules.d --with-systemdsystemunitdir=%(installdir)s/lib/systemd/system '
+
+sanity_check_paths = {
+    'files': ['lib/libcxi.%s' % SHLIB_EXT,
+              'include/libcxi/libcxi.h'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libcxi/libcxi-0f3609b.eb
+++ b/easybuild/easyconfigs/l/libcxi/libcxi-0f3609b.eb
@@ -48,6 +48,10 @@ builddependencies = [
 preconfigopts  = './autogen.sh && '
 configopts = 'CFLAGS="-Wno-error -D_FILE_OFFSET_BITS=64 -I../cxi-driver/include" --with-udevrulesdir=%(installdir)s/lib/udev/rules.d --with-systemdsystemunitdir=%(installdir)s/lib/systemd/system '
 
+postinstallcmds  = [
+    'cp -r ../cxi-driver/include/linux %(installdir)s/include && cp -r ../cxi-driver/include/uapi %(installdir)s/include && cp -r ../cassini-headers/install/include/* %(installdir)s/include && cp -r ../cassini-headers/install/share %(installdir)s'
+]
+
 sanity_check_paths = {
     'files': ['lib/libcxi.%s' % SHLIB_EXT,
               'include/libcxi/libcxi.h'],

--- a/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
+++ b/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
@@ -44,7 +44,7 @@ checksums = [
 ]
 
 builddependencies = [
-    ('rocm/6.2.2',              EXTERNAL_MODULE),
+    ('rocm', '6.2.2', '',       SYSTEM),
     ('libconfig', '1.7.3', '',  SYSTEM),
     ('libuv', '1.48.0', '',     SYSTEM),
     ('lm-sensors', '3.6.0', '', SYSTEM),

--- a/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
+++ b/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'libcxi'
-version = '0f3609b'
+version = 'shs-12.0.1'
 
 homepage = 'https://github.com/HewlettPackard/shs-libcxi'
 description = "The CXI library provides interfaces which interact directly with CXI drivers. CXI drivers support communication over the Cray Cassini NIC."
@@ -10,11 +10,11 @@ toolchain = SYSTEM
 
 sources = [
     {
-        'filename': '%(name)s.tar.gz',
+        'filename': '%(name)s-%(version)s.tar.gz',
         'git_config': {
             'url': 'https://github.com/HewlettPackard',
             'repo_name': 'shs-libcxi',
-            'commit': '0f3609b5e224636abffc7ceffe6f4e9c83244c08'
+            'commit': 'release/%(version)s'
         },
      },
     {
@@ -22,7 +22,7 @@ sources = [
         'git_config': {
             'url': 'https://github.com/HewlettPackard',
             'repo_name': 'shs-cassini-headers',
-            'commit': '9a8a738a879f007849fbc69be8e3487a4abf0952',
+            'commit': 'release/%(version)s',
             'clone_into': '../cassini-headers/install'
         },
      },
@@ -31,10 +31,16 @@ sources = [
         'git_config': {
             'url': 'https://github.com/HewlettPackard',
             'repo_name': 'shs-cxi-driver',
-            'commit': '751ebc4263827e2b47e3b2b89aa6f37824824ff2',
+            'commit': 'release/%(version)s',
             'clone_into': '../cxi-driver'
         },
      },
+]
+
+checksums = [
+  'bb58ca0f50b759f929a09ffff757966b642181ca61f05cfba94af30c43944d92',
+  'f97b4c4b039f9c3d543e43fc843a95b0915a7db01a8474468465a060b80d3572',
+  '4e71f1337b9ce9bb71c8469dff3f86e99fbfe8ba5d0584ffcc62f0c4ebfed42b',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
+++ b/easybuild/easyconfigs/l/libcxi/libcxi-shs-12.0.1.eb
@@ -44,11 +44,11 @@ checksums = [
 ]
 
 builddependencies = [
-    ('rocm', EXTERNAL_MODULE),
-    ('libconfig', '1.7.3', '', SYSTEM),
-    ('libuv', '1.48.0', '', SYSTEM),
+    ('rocm/6.2.2',              EXTERNAL_MODULE),
+    ('libconfig', '1.7.3', '',  SYSTEM),
+    ('libuv', '1.48.0', '',     SYSTEM),
     ('lm-sensors', '3.6.0', '', SYSTEM),
-    ('FUSE', '2.9.9', '', SYSTEM),
+    ('FUSE', '2.9.9', '',       SYSTEM),
 ]
 
 preconfigopts  = './autogen.sh && '

--- a/easybuild/easyconfigs/l/libuv/libuv-1.48.0.eb
+++ b/easybuild/easyconfigs/l/libuv/libuv-1.48.0.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'libuv'
+version = '1.48.0'
+
+homepage = 'https://libuv.org'
+description = "libuv is a multi-platform support library with a focus on asynchronous I/O."
+
+toolchain = SYSTEM
+
+github_account = 'libuv'
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['8c253adb0f800926a6cbd1c6576abae0bc8eb86a4f891049b72f9e5b7dc58f33']
+
+preconfigopts = './autogen.sh; '
+
+sanity_check_paths = {
+    'files': ['include/uv.h', 'lib/libuv.a', 'lib/libuv.%s' % SHLIB_EXT, 'lib/pkgconfig/libuv.pc'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/lm-sensors/lm-sensors-3.6.0.eb
+++ b/easybuild/easyconfigs/l/lm-sensors/lm-sensors-3.6.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'lm-sensors'
+version = '3.6.0'
+
+homepage = 'https://github.com/groeck/lm-sensors/'
+description = "lm-sensors package provides user-space support for the hardware monitoring drivers in Linux."
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/groeck/lm-sensors/archive']
+sources = ['V3-6-0.tar.gz']
+
+configure_cmd = 'echo '
+
+installopts = 'PREFIX=%(installdir)s ETCDIR=%(installdir)s/etc'
+
+sanity_check_paths = {
+    'files': ['lib/libsensors.%s' % SHLIB_EXT,
+              'include/sensors/sensors.h'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This is recipe for `libcxi` from https://github.com/HewlettPackard/shs-libcxi and dependency libraries in specific versions. To be build with system toolchain and minimal other dependencies. Relies on additional HPE repos (for header files only):
- https://github.com/HewlettPackard/shs-cxi-driver
- https://github.com/HewlettPackard/shs-cassini-headers
This follows spack package configuration.