### PR TITLE
Libfabric update with custom cxi user-level api

### DIFF
--- a/easybuild/easyconfigs/l/libfabric/libfabric-2.0.0-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-2.0.0-cpeGNU-24.03.eb
@@ -1,0 +1,50 @@
+easyblock = 'ConfigureMake'
+
+name = 'libfabric'
+version = '2.0.0'
+
+homepage = 'https://ofiwg.github.io/libfabric/'
+description = """
+Libfabric is a core component of OFI. It is the library that defines and exports
+the user-space API of OFI, and is typically the only software that applications
+deal with directly. It works in conjunction with provider libraries, which are
+often integrated directly into libfabric.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+
+source_urls = ['https://github.com/ofiwg/libfabric/releases/download/v%(version)s']
+sources = [SOURCE_TAR_BZ2]
+
+patches = [
+    ('6e4daf164090e59ed808794b0d739cf1c39fd4ac.patch'),
+]
+
+checksums = [
+    {'libfabric-2.0.0.tar.bz2': '1a8e40f1f331d6ee2e9ace518c0088a78c8a838968f8601c2b77fd012a7bf0f5'},
+    {'6e4daf164090e59ed808794b0d739cf1c39fd4ac.patch': 'e5815f9ece1db126a2fa998808c3310416c1e3354cf1823bcb30bd7f8e6f1ff6'},
+]
+
+dependencies = [
+    ('rocm', EXTERNAL_MODULE),
+    ('libcxi', '0f3609b', '', SYSTEM),
+    ('json-c', '0.17'),
+]
+
+preconfigopts = 'module unload libfabric && '
+
+configopts = '--enable-cxi=${EBROOTLIBCXI} --with-rocr=${ROCM_PATH} --with-json-c=${EBROOTJSONMINUSC} --with-cxi-uapi-headers=${EBROOTLIBCXI} --with-cassini-headers=${EBROOTLIBCXI} '
+
+prebuildopts = 'module unload libfabric && '
+
+sanity_check_paths = {
+    'files': ['lib/libfabric.%s' % SHLIB_EXT,
+              'include/rdma/fabric.h'],
+    'dirs': ['lib', 'include/rdma'],
+}
+
+modluafooter = """
+conflict( 'libfabric' )
+"""
+
+moduleclass = 'lib'


### PR DESCRIPTION
Depends on #235.

Allows `lnx` provider, to be used with OpenMPI5.