### PR TITLE
PETSC with external Kokkos libs 

### DIFF
--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
@@ -14,8 +14,8 @@ local_MUMPS_version        = '5.6.1'
 local_Hypre_version        = '2.31.0'
 local_SuperLU_version      = '6.0.1'
 local_SuperLU_DIST_version = '9.0.0'
-local_Kokkos_version       = '4.5.01'
-local_Kokkos_kernels_ver   = '4.5.01'
+local_Kokkos_version       = '4.3.00'
+local_Kokkos_kernels_ver   = '4.3.00'
 
 local_PETSc_version = '3.21.5'
 

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
@@ -60,7 +60,7 @@ dependencies = [
 ]
 
 # This is important while some packages are installed prior to build
-keeppreviousinstall = True
+#keeppreviousinstall = True
 
 preconfigopts = ' && '.join([
     'export HIPCC_COMPILE_FLAGS_APPEND="$(CC --cray-print-opts=cflags)"',

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.21.5-cpeGNU-24.03-rocm.eb
@@ -14,6 +14,8 @@ local_MUMPS_version        = '5.6.1'
 local_Hypre_version        = '2.31.0'
 local_SuperLU_version      = '6.0.1'
 local_SuperLU_DIST_version = '9.0.0'
+local_Kokkos_version       = '4.5.01'
+local_Kokkos_kernels_ver   = '4.5.01'
 
 local_PETSc_version = '3.21.5'
 
@@ -53,6 +55,8 @@ dependencies = [
     ('Hypre',              local_Hypre_version),
     ('SuperLU',            local_SuperLU_version,      '-OpenMP'),
     ('SuperLU_DIST',       local_SuperLU_DIST_version, '-OpenMP'),
+    ('Kokkos',             local_Kokkos_version,       '-rocm'),
+    ('Kokkos-kernels',     local_Kokkos_kernels_ver,   '-rocm'),
 ]
 
 # This is important while some packages are installed prior to build
@@ -135,8 +139,10 @@ configopts = ' '.join([
     '--with-hip',
     '--with-hipc=hipcc',
     '--with-hip-arch=gfx90a',
-    '--download-kokkos=yes',
-    '--download-kokkos-kernels=yes',
+    '--with-kokkos=1',
+    '--with-kokkos-dir="$EBROOTKOKKOS"',
+    '--with-kokkos-kernels=1',
+    '--with-kokkos-kernels-dir="$EBROOTKOKKOSMINUSKERNELS"',
     '--LIBS="-lgfortran -lgcc -lstdc++"',
     '--with-python-exec="$CRAY_PYTHON_PREFIX"/bin/python3',
 ])


### PR DESCRIPTION
This provides clean recipe for building PETSc with Kokkos libraries as dependency modules.
Depends on #232 