### PR TITLE
Removed the checksums of libxc as files are known to have changed over time

### DIFF
--- a/easybuild/easyconfigs/l/libxc/README.md
+++ b/easybuild/easyconfigs/l/libxc/README.md
@@ -47,3 +47,6 @@ tested and reliable set of LDA, GGA, and meta-GGA  functionals.
 ### Version 7.0.0 for cpeGNU 24.03
 
 -   Derived from the 6.2.2 EasyConfig.
+
+-   **NOTE**: Update on March 31, 2025: Disabled checksums as they seem unstable on 
+    on the GitLab.

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-23.12.eb
@@ -40,7 +40,7 @@ toolchainopts = {'opt': True}
 
 source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
 sources = [SOURCE_TAR_BZ2]
-checksums = ['f72ed08af7b9dff5f57482c5f97bff22c7dc49da9564bc93871997cbda6dacf3']
+#checksums = ['f72ed08af7b9dff5f57482c5f97bff22c7dc49da9564bc93871997cbda6dacf3']
 
 builddependencies = [
     ('buildtools',          '%(toolchain_version)s', '', True), # For CMake

--- a/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-6.2.2-cpeGNU-24.03.eb
@@ -40,7 +40,7 @@ toolchainopts = {'opt': True}
 
 source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
 sources = [SOURCE_TAR_BZ2]
-checksums = ['ec292de621e819b03a37db1f7a7365a9eaf423e30e2fd4553e6336eca534cc29']
+#checksums = ['ec292de621e819b03a37db1f7a7365a9eaf423e30e2fd4553e6336eca534cc29']
 
 builddependencies = [
     ('buildtools', '%(toolchain_version)s', '', True), # For CMake

--- a/easybuild/easyconfigs/l/libxc/libxc-7.0.0-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-7.0.0-cpeGNU-24.03.eb
@@ -41,7 +41,7 @@ toolchainopts = {'opt': True}
 source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
 sources = [SOURCE_TAR_BZ2]
 #checksums = ['f72ed08af7b9dff5f57482c5f97bff22c7dc49da9564bc93871997cbda6dacf3']
-checksums = ['e9ae69f8966d8de6b7585abd9fab588794ada1fab8f689337959a35abbf9527d']  # libxc-7.0.0.tar.bz2
+#checksums = ['e9ae69f8966d8de6b7585abd9fab588794ada1fab8f689337959a35abbf9527d']  # libxc-7.0.0.tar.bz2
 
 builddependencies = [
     ('buildtools', '%(toolchain_version)s', '', True), # For CMake


### PR DESCRIPTION
See also https://github.com/easybuilders/easybuild-easyconfigs/issues/20417/