### PR TITLE
Add CubeLib v4.9

### DIFF
--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAMD-24.03.eb
@@ -1,0 +1,68 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'       # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAOCC-24.03.eb
@@ -1,0 +1,66 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'          # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'        # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeCray-24.03.eb
@@ -1,0 +1,71 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'          # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'        # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeGNU-24.03.eb
@@ -1,0 +1,71 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'          # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'        # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/README.md
+++ b/easybuild/easyconfigs/c/CubeLib/README.md
@@ -1,4 +1,4 @@
-# ubeLib
+# CubeLib
 
 - [CubeLib web site](https://www.scalasca.org/scalasca/software/cube-4.x/download.html)
 


### PR DESCRIPTION
Part of updating Score-P and Scalasca to latest releases.
Drops static library checks, as only shared or static libraries are built now.