### PR TITLE
Add CubeWriter v4.9

### DIFF
--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAMD-24.03.eb
@@ -1,0 +1,69 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAOCC-24.03.eb
@@ -1,0 +1,69 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeCray-24.03.eb
@@ -1,0 +1,69 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeGNU-24.03.eb
@@ -1,0 +1,69 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
Part of updating Score-P and Scalasca to latest releases.
Drops static library checks, as only shared or static libraries are built now.