### PR TITLE
Add OTF2 v3.1.1

### DIFF
--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAMD-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAMD-24.03.eb
@@ -1,0 +1,65 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAOCC-24.03.eb
@@ -1,0 +1,65 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeCray-24.03.eb
@@ -1,0 +1,65 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeGNU-24.03.eb
@@ -1,0 +1,65 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'


### PR DESCRIPTION
Part of updating Score-P and Scalasca to latest releases.
Drops static library checks, as only shared or static libraries are built now.