### PR TITLE
Add Score-P v9.0

### DIFF
--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeAMD-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeAMD-24.03-rocm.eb
@@ -1,0 +1,98 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.0'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeAMD', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    '5d0a5db4cc6f31c30ae03c7e6f6245e83667b0ff38a7041ffe8b2e8e581e0997',  # scorep-9.0.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter.
+    ('rocm',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeAMD-24.03-rocm '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+# Disable LLVM IR plug-in, as ROCm invokes lld when generating object files,
+# passing LLVM IR arguments when it shouldn't
+configopts += '--disable-llvm-plugin '
+
+postinstallcmds = ['make installcheck V=1 VERBOSE=1']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeAOCC-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeAOCC-24.03.eb
@@ -1,0 +1,92 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+#DOC Score-P without the HIP-adapter for the regular compute nodes.
+#DOC The build process takes a while (up to 1 hour) due to lengthy configure and postprocessing steps.
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.0'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Score-P'
+version = local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+
+toolchain = {'name': 'cpeAOCC', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources = ['scorep-%(version)s.tar.gz']
+checksums = [
+    '5d0a5db4cc6f31c30ae03c7e6f6245e83667b0ff38a7041ffe8b2e8e581e0997',  # scorep-9.0.tar.gz
+]
+
+builddependencies = [
+    ('CubeLib',    local_CubeLib_version),
+    ('CubeWriter', local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',  local_libunwind_version),
+]
+
+dependencies = [
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeAOCC-24.03 '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+
+postinstallcmds = ['make installcheck']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeCray-24.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeCray-24.03-rocm.eb
@@ -1,0 +1,98 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.0'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    '5d0a5db4cc6f31c30ae03c7e6f6245e83667b0ff38a7041ffe8b2e8e581e0997',  # scorep-9.0.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter.
+    ('rocm',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-24.03-rocm '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+# Disable LLVM IR plug-in, to avoid issues because of minor version differences
+# of ROCm & Cray LLVM. LLVM IR plugin is not available for Cray compilers anyway.
+configopts += '--disable-llvm-plugin '
+
+postinstallcmds = ['make installcheck V=1 VERBOSE=1']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeCray-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeCray-24.03.eb
@@ -1,0 +1,90 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.0'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeCray', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    '5d0a5db4cc6f31c30ae03c7e6f6245e83667b0ff38a7041ffe8b2e8e581e0997',  # scorep-9.0.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-24.03 '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+
+postinstallcmds = ['make installcheck V=1 VERBOSE=1']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.0-cpeGNU-24.03.eb
@@ -1,0 +1,92 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.0'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.42'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    '5d0a5db4cc6f31c30ae03c7e6f6245e83667b0ff38a7041ffe8b2e8e581e0997',  # scorep-9.0.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeGNU-24.03 '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Force set correct GCC compilers, as Score-P will use /usr/bin/gcc otherwise
+configopts += 'CC=gcc-13 CXX=g++-13 F77=gfortran-13 FC=gfortran-13 '
+
+postinstallcmds = ['make installcheck V=1 VERBOSE=1']
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+


### PR DESCRIPTION
Requires:
- [ ] #252
- [ ] #253
- [ ] #254
- [ ] #255
- [ ] #256

----

A patch to improve the OpenMP Tools Interface might follow later, once merged in Score-P.
For now, this matches the Score-P v9.0 release.