### PR TITLE
EasyConfigs for CuPy/Magma/ELPA that depend explicitly on rocm/6.2.2

### DIFF
--- a/easybuild/easyconfigs/c/CuPy/CuPy-13.2.0-cpeGNU-24.03-rocm6.2.2.eb
+++ b/easybuild/easyconfigs/c/CuPy/CuPy-13.2.0-cpeGNU-24.03-rocm6.2.2.eb
@@ -1,0 +1,75 @@
+easyblock = 'PythonPackage'
+
+local_CuPy_version      = '13.2.0'
+local_fastrlock_version = '0.8.2'
+
+name = 'CuPy'
+version = local_CuPy_version
+versionsuffix = '-rocm6.2.2'
+
+homepage = 'https://cupy.dev'
+
+whatis = [
+    'Description: CuPy is an open-source array library for GPU-accelerated computing with Python'
+]
+
+description = """"
+CuPy is an open-source array library for GPU-accelerated computing with Python.
+CuPy acts as a drop-in replacement to run existing NumPy/SciPy code on NVIDIA CUDA
+or AMD ROCm platforms.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['CuPy-13.2.0_rocm-6.patch']
+
+checksums = [
+    'e4dbd2b2ed4159a5cc0c0f98a710a014950eb2c16eeb455e956128f3b3bd0d51', # cupy-13.2.0.tar.gz
+    'ab13ae53fc74da4cd94e6c31ceef22d021edf8a8a048e4e5af86d34ba7be2683', # CuPy-13.2.0_rocm-6.patch
+]
+
+builddependencies = [
+    # Provides wheel
+    ('buildtools-python', '%(toolchain_version)s', '-cray-python%(pyshortver)s', True),
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('rocm', '6.2.2', '', SYSTEM)
+]
+
+use_pip = True
+
+local_include_dirs = ['hipblas', 'hipsparse', 'hipfft', 'rocsolver', 'rccl']
+
+preinstallopts = ' && '.join([
+    'export ROCM_HOME=$(readlink -f $ROCM_PATH)',
+    'export CUPY_INSTALL_USE_HIP=1',
+    'export HCC_AMDGPU_TARGET=gfx90a',
+    'export CFLAGS="-w $CFLAGS"', 
+]) + ' && '
+
+skipsteps = ['build']
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True
+}
+
+exts_list = [
+    ('fastrlock', local_fastrlock_version)
+]
+
+sanity_check_paths = {
+    'files': [
+        'lib/python%(pyshortver)s/site-packages/cupyx/cusolver.cpython-311-x86_64-linux-gnu.so',
+        'lib/python%(pyshortver)s/site-packages/fastrlock/rlock.cpython-311-x86_64-linux-gnu.so'
+    ],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeGNU-24.03-rocm6.2.2.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeGNU-24.03-rocm6.2.2.eb
@@ -1,0 +1,91 @@
+# Contributed by Luca Marsella (CSCS)
+# Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
+# GPU version adapted for LUMI
+easyblock = 'ConfigureMake'
+
+local_ELPA_version = '2024.05.001'
+
+name =    'ELPA'
+version = local_ELPA_version
+versionsuffix = '-rocm6.2.2'
+
+homepage = 'http://elpa.mpcdf.mpg.de'
+
+whatis = [
+    "Description: ELPA - Eigenvalue SoLvers for Petaflop-Applications",
+]
+
+description = """
+The publicly available ELPA library provides highly efficient and highly
+scalable direct eigensolvers for symmetric matrices. Though especially designed
+for use for PetaFlop/s applications solving large problem sizes on massively
+parallel supercomputers, ELPA eigensolvers have proven to be also very efficient
+for smaller matrices. All major architectures are supported.
+
+ELPA provides static and shared libraries with and without OpenMP support
+and with and without MPI. GPU kernels are not included in this module.
+"""
+
+docurls = [
+    'Manual pages in section 1 and 3'
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'usempi': True, 'openmp': False}
+
+source_urls = ['https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/%(version)s/']
+sources =  ['elpa-%(version)s.tar.gz']
+checksums = ['9caf41a3e600e2f6f4ce1931bd54185179dade9c171556d0c9b41bbc6940f2f6']
+
+builddependencies = [ 
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('rocm/6.2.2',  EXTERNAL_MODULE),
+]
+
+configopts = ' '.join([
+    'CPP=cpp CC=cc CXX=hipcc FC=ftn',
+    'CFLAGS="-g $CFLAGS"',
+    'FCFLAGS="-g $FCFLAGS"',
+    'CXXFLAGS="-g --offload-arch=gfx90a -std=c++17 -I$ROCM_PATH/include/hip -I$ROCM_PATH/include/ -I$ROCM_PATH/include/rocsolver -I$CRAY_MPICH_DIR/include"',
+    '--enable-static',
+    '--disable-generic',
+    '--disable-sse',
+    '--disable-avx',
+    '--enable-avx2',
+    '--disable-avx512',
+    '--enable-amd-gpu-kernels',
+    '--with-AMD-gpu-support-only',
+    '--enable-gpu-streams=amd',
+    '--enable-hipcub',
+    '--enable-single-precision ',
+    '--disable-openmp',
+    '--with-mpi=yes',
+    '--enable-cuda-aware-mpi',
+# Disable hipblas because detection of the v3 api is a completly broken test
+# copy-pasted from the rocblas one, with the wrong include and floating point type.
+#    '--enable-marshalling-hipblas-library',
+])
+
+prebuildopts = 'export CPATH=$ROCM_PATH/include/hipblas && make clean && '
+
+maxparallel = 16
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so'],
+    'dirs':  ['bin', 'lib/pkgconfig',
+              'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules',]
+}
+
+modextrapaths = {
+    'CPATH': ['include/elpa-%(version)s']
+}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa-%(version)s',
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeGNU-24.03-rocm6.2.2.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2024.05.001-cpeGNU-24.03-rocm6.2.2.eb
@@ -1,6 +1,7 @@
 # Contributed by Luca Marsella (CSCS)
 # Some adaptations by Kurt Lust (University of Antwerpen and LUMI consortium)
 # GPU version adapted for LUMI
+# Modified for rocm/6.2.2 by Lauri Niemi (CSC)
 easyblock = 'ConfigureMake'
 
 local_ELPA_version = '2024.05.001'

--- a/easybuild/easyconfigs/m/magma/magma-2.8.0-cpeGNU-24.03-rocm6.2.2.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.8.0-cpeGNU-24.03-rocm6.2.2.eb
@@ -1,0 +1,95 @@
+# Created for LUMI by Orian Louant
+# Modified by Lauri Niemi for ROCm 6.2.2
+easyblock = "CMakeMake"
+
+name = 'magma'
+version = '2.8.0'
+versionsuffix = '-rocm6.2.2'
+
+homepage = 'https://icl.cs.utk.edu/magma/'
+
+whatis = ['Description: MAGMA, Matrix Algebra on GPU and Multi-core Architectures']
+
+description = """
+Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection of
+next-generation linear algebra libraries for heterogeneous computing. The MAGMA
+package supports interfaces for current linear algebra packages and standards
+(e.g., LAPACK and BLAS) to enable computational scientists to easily port any
+linear algebra–reliant software components to heterogeneous computing systems.
+MAGMA enables applications to fully exploit the power of current hybrid systems
+of many-core CPUs and multi-GPUs/coprocessors to deliver the fastest possible
+time to accurate solutions within given energy constraints.
+
+MAGMA features LAPACK-compliant routines for multi-core CPUs enhanced with
+NVIDIA or AMD GPUs. MAGMA includes more than 400 routines that cover one-sided
+dense matrix factorizations and solvers, two-sided factorizations, and
+eigen/singular-value problem solvers, as well as a subset of highly optimized
+BLAS for GPUs.
+"""
+
+docurls = [
+    'Magma documentation available here https://icl.utk.edu/projectsfiles/magma/doxygen/index.html'
+]
+
+local_pkgconfig_file = """
+prefix=%(installdir)s
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: magma
+Description: Matrix Algebra on GPU and Multicore Architectures
+Version: 2.8.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmagma_sparse -lmagma
+Libs.private:
+Requires:
+Requires.private:
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+source_urls = ['https://icl.cs.utk.edu/projectsfiles/magma/downloads/']
+sources = [SOURCE_TAR_GZ]
+patches = ['magma-2.8.0_separate-cxx-and-hip-compilation.patch']
+
+checksums = [
+    'f4e5e75350743fe57f49b615247da2cc875e5193cc90c11b43554a7c82cc4348', # magma-2.8.0.tar.gz
+    '72d89534fe8a15ea42821a06b8a5b07d78039d0c7e493915f9a9581d3a5d8308', # magma-2.8.0_separate-cxx-and-hip-compilation.patch
+]
+
+builddependencies = [
+    ('buildtools',          '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    # Load rocm/6.2.2 as EXTERNAL_MODULE to ensure Magma's CMake build finds it instead of 6.0.3
+    ('rocm/6.2.2', EXTERNAL_MODULE),
+]
+
+local_configopts_base = ' '.join([
+    '-DCMAKE_HIP_COMPILER=${ROCM_PATH}/bin/amdclang++', 
+    '-DMAGMA_ENABLE_HIP=ON',
+    '-DCMAKE_HIP_ARCHITECTURES=gfx90a',
+    '-DCMAKE_HIP_FLAGS=-O3',
+])
+
+configopts = [
+    local_configopts_base,
+    local_configopts_base + ' -DBUILD_SHARED_LIBS=OFF',
+]
+
+postinstallcmds = [
+    'cd %(installdir)s/lib/pkgconfig/; rm -f magma.pc',
+    'cd %(installdir)s/lib/pkgconfig/; cat >magma.pc <<EOF\n' + local_pkgconfig_file.replace('$', '\$') + '\nEOF\n'
+    'cd %(installdir)s/lib/pkgconfig/; chmod a+r magma.pc'
+]
+
+sanity_check_paths = {
+    'files': ['lib/libmagma.so', 'lib/libmagma.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/magma/magma-2.8.0-cpeGNU-24.03-rocm6.2.2.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.8.0-cpeGNU-24.03-rocm6.2.2.eb
@@ -1,5 +1,5 @@
 # Created for LUMI by Orian Louant
-# Modified by Lauri Niemi for ROCm 6.2.2
+# Modified for ROCm 6.2.2 by Lauri Niemi (CSC)
 easyblock = "CMakeMake"
 
 name = 'magma'


### PR DESCRIPTION
Added EasyConfig files for ensuring `rocm/6.2.2` dependency, instead of the depending on the default `rocm` module (which is 6.0.3).

The motivation here is that CuPy in particular seems to have issues on 6.0.3 and makes it hard to run GPAW on Lumi-G, see eg. https://gitlab.com/gpaw/gpaw/-/merge_requests/2724. On `rocm/6.2.2` things work better.