### PR TITLE
GPAW 25.1.0 and libvdwxc 0.4.0

### DIFF
--- a/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-cpeGNU-24.03.eb
@@ -1,0 +1,75 @@
+easyblock = "PythonPackage"
+
+name = 'GPAW'
+version = '25.1.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
+description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
+ method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or
+ atom-centered basis-functions."""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = [{
+     'filename': SOURCELOWER_TAR_GZ,
+     'source_urls': [PYPI_LOWER_SOURCE],
+},
+{
+     # Old setups are OK for 25.1.0
+     'filename': 'gpaw-setups-24.1.0.tar.gz',
+     'source_urls': ['https://wiki.fysik.dtu.dk/gpaw-files/'],
+}
+]
+patches = [
+   {'name': 'GPAW-25.1.0-siteconfig-cpu.patch', 'level': 1},
+   {'name': 'GPAW-25.1.0-fix-ase-version.patch', 'level': 1},
+   {'name': 'GPAW-25.1.0-test-nosave-projections.patch', 'level': 1},
+   {'name': 'GPAW-25.1.0-test-gauss-func.patch', 'level': 1},
+]
+checksums = [
+    {'gpaw-25.1.0.tar.gz': '80236e779784df3317e7da395dc59ea403bc0213bb3a68d02c17957162e972ea'},
+    {'gpaw-setups-24.1.0.tar.gz': '314d43168f7b57a2d942855d3d5ad21da9ef74e772d37343d416305113a95c23'},
+    {'GPAW-25.1.0-siteconfig-cpu.patch': '12682be6f65a990ddd1c17a21f14c9f8fa681890f410d356bf5474255f5f2912'},
+    {'GPAW-25.1.0-fix-ase-version.patch': '23c76f4769ab44da1406828b0c39da75783b53428f3bfc395bbac92fe7264c1d'},
+    {'GPAW-25.1.0-test-nosave-projections.patch': 'cf8f56058885633ec0c745223d5ef8ac2fa0dc4d18955ea41308ebce99f026cf'},
+    {'GPAW-25.1.0-test-gauss-func.patch': 'a6428a529eec59f113bc7e6b384ac2c4bed2cd72da227cb33a40137dbde2ae40'},
+]
+
+builddependencies = [
+    # Provides wheel
+    ('buildtools-python', '%(toolchain_version)s', '-cray-python%(pyshortver)s', True),
+]
+
+dependencies = [
+    ('cray-python/3.11.7', EXTERNAL_MODULE),
+    ('cray-fftw/3.3.10.7', EXTERNAL_MODULE),
+    ('libxc', '7.0.0'),
+    ('libvdwxc', '0.4.0'),
+]
+
+preinstallopts = 'GPAW_CONFIG=siteconfig-lumi-cpu.py '
+
+download_dep_fail = False
+use_pip = True
+use_pip_for_deps = True
+pip_verbose = True
+pip_ignore_installed = False
+pip_no_index = False
+sanity_pip_check = True
+
+postinstallcmds = ['cp -rp ../gpaw-setups-24.1.0 %(installdir)s/']
+
+sanity_check_paths = {
+    'files': ['bin/gpaw%s' % x for x in ['', '-analyse-basis', '-basis', '-plot-parallel-timings',
+                                         '-runscript', '-setup', '-upfplot']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "gpaw info"
+]
+
+modextravars = {'GPAW_SETUP_PATH': '%(installdir)s/gpaw-setups-24.1.0'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-fix-ase-version.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-fix-ase-version.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 9ea28ce7d..b09894925 100644
+--- a/setup.py
++++ b/setup.py
+@@ -397,7 +397,7 @@ setup(name='gpaw',
+           'console_scripts': ['gpaw = gpaw.cli.main:main']},
+       setup_requires=['numpy'],
+       python_requires=python_requires,
+-      install_requires=[f'ase>={ase_version_required}',
++      install_requires=['ase==3.24.0',
+                         'numpy',
+                         'scipy>=1.6.0'],
+       extras_require={'docs': ['sphinx-rtd-theme',

--- a/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-siteconfig-cpu.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-siteconfig-cpu.patch
@@ -1,0 +1,41 @@
+--- /dev/null
++++ b/siteconfig-lumi-cpu.py
+@@ -0,0 +1,38 @@
++"""Custom GPAW siteconfig for LUMI-C."""
++
++parallel_python_interpreter = True
++
++mpi = True
++compiler = 'cc'
++compiler_args = []  # remove all default args
++libraries = []
++library_dirs = []
++include_dirs = []
++extra_compile_args = [
++    '-g',
++    '-O3',
++    '-fopenmp',
++    '-fPIC',
++    '-Wall',
++    '-Wno-stringop-overflow',  # suppress warnings from MPI_STATUSES_IGNORE
++    '-Wno-deprecated-declarations',  # PySys_SetArgv() etc deprecated in Python 3.11
++    '-Werror',
++    ]
++extra_link_args = ['-fopenmp']
++
++# FFTW
++fftw = True
++libraries += ['fftw3']
++
++# ScaLAPACK
++# Note: required libraries are linked by compiler wrappers
++scalapack = True
++
++# Libxc
++libraries += ['xc']
++
++# Libvdwxc
++libvdwxc = True
++libraries += ['vdwxc']
++
++define_macros += [('GPAW_ASYNC', 1)]

--- a/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-test-gauss-func.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-test-gauss-func.patch
@@ -1,0 +1,13 @@
+diff --git a/gpaw/test/test_gauss_func.py b/gpaw/test/test_gauss_func.py
+index 60e1072..478cab3 100644
+--- a/gpaw/test/test_gauss_func.py
++++ b/gpaw/test/test_gauss_func.py
+@@ -34,7 +34,7 @@ def test_gauss_func():
+         for mL in range(9):
+             m = gauss.get_moment(g, mL)  # the mL'th moment of g
+             print(f'  {mL}\'th moment = {m:2.6f}')
+-            assert m == pytest.approx(gL == mL, abs=1e-4)
++            assert m == pytest.approx(float(gL == mL), abs=1e-4)
+ 
+     # Check the moments of the constructed 1s density
+     print('\nDensity of Hydrogen atom')

--- a/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-test-nosave-projections.patch
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-25.1.0-test-nosave-projections.patch
@@ -1,0 +1,13 @@
+diff --git a/gpaw/test/test_nosave_projections.py b/gpaw/test/test_nosave_projections.py
+index 9dfd470a3..f60ddbb5d 100644
+--- a/gpaw/test/test_nosave_projections.py
++++ b/gpaw/test/test_nosave_projections.py
+@@ -45,7 +45,7 @@ def test_nice_error_message(noprojs_gpw):
+         wfs.P_ani
+ 
+ 
+-def test_fixed_density_bandstructure(tmp_path, noprojs_gpw):
++def test_fixed_density_bandstructure(noprojs_gpw):
+     calc = GPAW(noprojs_gpw, parallel=parallel)
+ 
+     fixed_calc = calc.fixed_density(

--- a/easybuild/easyconfigs/l/libvdwxc/LICENSE.md
+++ b/easybuild/easyconfigs/l/libvdwxc/LICENSE.md
@@ -1,0 +1,3 @@
+# libvdwxc license
+
+libvdwxc is licensed under the GNU General Public License. (https://www.gnu.org/licenses/gpl-3.0.en.html). See the [COPYING file](https://gitlab.com/libvdwxc/libvdwxc/-/blob/master/COPYING) for a detailed description.

--- a/easybuild/easyconfigs/l/libvdwxc/README.md
+++ b/easybuild/easyconfigs/l/libvdwxc/README.md
@@ -1,0 +1,13 @@
+# libvdwxc
+
+- [libvdwxc documentation](https://libvdwxc.materialsmodeling.org/)
+- [libvdwxc on Gitlab](https://gitlab.com/libvdwxc/libvdwxc)
+
+## EasyBuild
+
+- [libvdwxc support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/l/libvdwxc)
+
+### libvdwxc 0.4.0 for cpuGNU 24.03
+
+- EasyConfig file from the EasyBuilders repository adapted for LUMI
+

--- a/easybuild/easyconfigs/l/libvdwxc/libvdwxc-0.4.0-cpuGNU-24.03.eb
+++ b/easybuild/easyconfigs/l/libvdwxc/libvdwxc-0.4.0-cpuGNU-24.03.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'libvdwxc'
+version = '0.4.0'
+
+homepage = 'https://libvdwxc.materialsmodeling.org/'
+description = """libvdwxc is a general library for evaluating energy and potential for
+exchange-correlation (XC) functionals from the vdW-DF family that can be used with various
+of density functional theory (DFT) codes."""
+
+toolchain = {'name': 'cpeGNU', 'version': '24.03'}
+toolchainopts = {'pic': True, 'openmp': False}
+
+source_urls = ['https://launchpad.net/libvdwxc/stable/%(version)s/+download/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['3524feb5bb2be86b4688f71653502146b181e66f3f75b8bdaf23dd1ae4a56b33']
+
+dependencies = [
+    ('cray-fftw/3.3.10.7', EXTERNAL_MODULE),
+]
+
+preconfigopts = 'unset CC && unset FC && '
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['libvdwxc_fdtest', 'libvdwxc_maintest',
+                                     'libvdwxc_q0test', 'libvdwxc_q0test2']] +
+             ['lib/lib%s.%s' % (x, y) for x in ['vdwxc', 'vdwxcfort']
+              for y in ['a', SHLIB_EXT]],
+    'dirs': ['include'],
+}


### PR DESCRIPTION
Added EasyConfig for GPAW 25.1.0 in partition/C (no GPU support). This recipe compiles GPAW with `libvdwxc` support and updates other dependencies to newer versions.