### PR TITLE
Update AdaptiveCpp to 25.03

### DIFF
--- a/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-25.02-cpeAMD-25.03-rocm.eb
+++ b/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-25.02-cpeAMD-25.03-rocm.eb
@@ -27,6 +27,7 @@ sources = [{
         'tag': 'v%(version)s',
     }
 }]
+
 checksums = ['3cb66d1e0f37feb3a79943b9562d268ede88cdf798379561adffd5935030fb62']
 
 builddependencies = [
@@ -44,7 +45,9 @@ preconfigopts += 'export C_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
 preconfigopts += 'export CPLUS_INCLUDE_PATH=$ROCM_PATH/llvm/include && '
 
 configopts  = '-DACPP_VERSION_SUFFIX="rocm6" '
+configopts += '-DACPP_EXPERIMENTAL_LLVM=ON '
 configopts += '-DROCM_PATH=$ROCM_PATH '
+configopts += '-DAMDGPU_TARGETS=gfx90a '
 configopts += '-DCMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/clang '
 configopts += '-DCMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/clang++ '
 configopts += '-DWITH_ACCELERATED_CPU=ON '
@@ -58,8 +61,6 @@ configopts += '-DBoost_NO_BOOST_CMAKE=TRUE '
 configopts += '-DBoost_NO_SYSTEM_PATHS=TRUE '
 configopts += '-DWITH_SSCP_COMPILER=OFF ' 
 configopts += '-DLLVM_DIR=${ROCM_PATH}/llvm/lib/cmake/llvm/ '
-configopts += '-DHIPSYCL_ALLOW_INSTANT_SUBMISSION=1 '
-configopts += '-DACPP_EXPERIMENTAL_LLVM=ON '
 
 sanity_check_paths = {
     'files': ['bin/acpp', 'include/AdaptiveCpp/sycl/sycl.hpp',


### PR DESCRIPTION
Update of AdaptiveCPP to 25.03

Note 
configopts += '-DACPP_EXPERIMENTAL_LLVM=ON '

is required for current version. Guess there is no reason to leave this in there, as LLVM version is set by easybuild anyway, so the error from experimental LLVM is not useful feedback from AdaptiveCpp