### PR TITLE
Draft: Score-P/Scalasca for cpeAMD/cpeGNU/cpeCray 25.03

### DIFF
--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeAMD-25.03.eb
@@ -1,0 +1,73 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'       # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeCray-25.03.eb
@@ -1,0 +1,73 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'       # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeLib/CubeLib-4.9-cpeGNU-25.03.eb
@@ -1,0 +1,73 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeLib_version =      '4.9'         # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'       # https://zlib.net/
+
+name =    'CubeLib'
+version = local_CubeLib_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeLib its general purpose C++ library component and command-line tools'
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube general purpose C++ library component and
+command-line tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubelib/tags/cubelib-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'a0658f5bf3f74bf7dcf465ab6e30476751ad07eb93618801bdcf190ba3029443',  # cubelib-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubelib-config',
+              ('lib/libcube4.%s' % SHLIB_EXT, 'lib64/libcube4.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubelib'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeAMD-25.03.eb
@@ -1,0 +1,74 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeCray-25.03.eb
@@ -1,0 +1,74 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/c/CubeWriter/CubeWriter-4.9-cpeGNU-25.03.eb
@@ -1,0 +1,74 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2018-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'CubeWriter'
+version = local_CubeWriter_version
+
+homepage = 'https://www.scalasca.org/software/cube-4.x/download.html'
+
+whatis = [
+    'Description: Cube is a performance report explorer, and CubeWriter its high-performance C Writer library',
+]
+
+description = """
+Cube, which is used as performance report explorer for Scalasca and Score-P,
+is a generic tool for displaying a multi-dimensional performance space
+consisting of the dimensions (i) performance metric, (ii) call path, and
+(iii) system resource. Each dimension can be represented as a tree, where
+non-leaf nodes of the tree can be collapsed or expanded to achieve the
+desired level of granularity.
+
+This module provides the Cube high-performance C writer library component.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/cubew/tags/cubew-%(version)s']
+sources = ['cubew-%(version)s.tar.gz']
+checksums = [
+    '4ef74e81c569bf53117459cba5a1ea52b5dac739493fa83be39678840cd2acdd',  # cubew-4.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/cubew-config',
+              ('lib/libcube4w.%s' % SHLIB_EXT, 'lib64/libcube4w.%s' % SHLIB_EXT)],
+    'dirs': ['include/cubew'],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeAMD-25.03.eb
@@ -1,0 +1,51 @@
+easyblock = "CMakeMake"
+
+name = "GOTCHA"
+
+local_GOTCHA_version = '1.0.8' # https://github.com/LLNL/GOTCHA/releases
+
+version = local_GOTCHA_version
+
+homepage = "https://gotcha.readthedocs.io/en/latest/"
+
+whatis = [
+    'Description: Gotcha is a library that wraps functions',
+]
+
+description = """Gotcha is a library that wraps functions. Tools can use gotcha to install hooks into other
+libraries, for example putting a wrapper function around libc's malloc. It is similar to LD_PRELOAD, but
+operates via a programmable API. This enables easy methods of accomplishing tasks like code instrumentation
+or wholesale replacement of mechanisms in programs without disrupting their source code."""
+
+docurls = [
+    'Web-based documentation of the latest version at https://gotcha.readthedocs.io/en/latest/api.html',  
+]
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/LLNL/GOTCHA/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['267ac6d02916863c8a360b192f1f36e4eaeb8945c73ae7f92116d6f801ad8184']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = [
+    "-DGOTCHA_ENABLE_TESTS=OFF",
+    "-DDEPENDENCIES_PREINSTALLED=ON"
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cd ../%(name)s-%(version)s && cp COPYRIGHT LGPL README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': [('lib/libgotcha.%s' % SHLIB_EXT, 'lib64/libgotcha.%s' % SHLIB_EXT),
+              'lib/cmake/gotcha/gotcha-config.cmake',
+              'include/gotcha/gotcha.h'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeCray-25.03.eb
@@ -1,0 +1,51 @@
+easyblock = "CMakeMake"
+
+name = "GOTCHA"
+
+local_GOTCHA_version = '1.0.8' # https://github.com/LLNL/GOTCHA/releases
+
+version = local_GOTCHA_version
+
+homepage = "https://gotcha.readthedocs.io/en/latest/"
+
+whatis = [
+    'Description: Gotcha is a library that wraps functions',
+]
+
+description = """Gotcha is a library that wraps functions. Tools can use gotcha to install hooks into other
+libraries, for example putting a wrapper function around libc's malloc. It is similar to LD_PRELOAD, but
+operates via a programmable API. This enables easy methods of accomplishing tasks like code instrumentation
+or wholesale replacement of mechanisms in programs without disrupting their source code."""
+
+docurls = [
+    'Web-based documentation of the latest version at https://gotcha.readthedocs.io/en/latest/api.html',  
+]
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/LLNL/GOTCHA/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['267ac6d02916863c8a360b192f1f36e4eaeb8945c73ae7f92116d6f801ad8184']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = [
+    "-DGOTCHA_ENABLE_TESTS=OFF",
+    "-DDEPENDENCIES_PREINSTALLED=ON"
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cd ../%(name)s-%(version)s && cp COPYRIGHT LGPL README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': [('lib/libgotcha.%s' % SHLIB_EXT, 'lib64/libgotcha.%s' % SHLIB_EXT),
+              'lib/cmake/gotcha/gotcha-config.cmake',
+              'include/gotcha/gotcha.h'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/g/GOTCHA/GOTCHA-1.0.8-cpeGNU-25.03.eb
@@ -1,0 +1,51 @@
+easyblock = "CMakeMake"
+
+name = "GOTCHA"
+
+local_GOTCHA_version = '1.0.8' # https://github.com/LLNL/GOTCHA/releases
+
+version = local_GOTCHA_version
+
+homepage = "https://gotcha.readthedocs.io/en/latest/"
+
+whatis = [
+    'Description: Gotcha is a library that wraps functions',
+]
+
+description = """Gotcha is a library that wraps functions. Tools can use gotcha to install hooks into other
+libraries, for example putting a wrapper function around libc's malloc. It is similar to LD_PRELOAD, but
+operates via a programmable API. This enables easy methods of accomplishing tasks like code instrumentation
+or wholesale replacement of mechanisms in programs without disrupting their source code."""
+
+docurls = [
+    'Web-based documentation of the latest version at https://gotcha.readthedocs.io/en/latest/api.html',  
+]
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/LLNL/GOTCHA/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['267ac6d02916863c8a360b192f1f36e4eaeb8945c73ae7f92116d6f801ad8184']
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+configopts = [
+    "-DGOTCHA_ENABLE_TESTS=OFF",
+    "-DDEPENDENCIES_PREINSTALLED=ON"
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cd ../%(name)s-%(version)s && cp COPYRIGHT LGPL README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': [('lib/libgotcha.%s' % SHLIB_EXT, 'lib64/libgotcha.%s' % SHLIB_EXT),
+              'lib/cmake/gotcha/gotcha-config.cmake',
+              'include/gotcha/gotcha.h'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeAMD-25.03.eb
@@ -1,0 +1,87 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'libbfd'
+version = local_libbfd_version
+
+homepage = 'https://www.gnu.org/software/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.45/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['8a3eb4b10e7053312790f21ee1a38f7e2bbd6f4096abb590d3429e5119592d96']
+
+builddependencies = [
+    ('buildtools',          '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts  = 'module unload rocm xpmem ; '
+prebuildopts   = preconfigopts
+preinstallopts = preconfigopts
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    prebuildopts + 'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeCray-25.03.eb
@@ -1,0 +1,87 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'libbfd'
+version = local_libbfd_version
+
+homepage = 'https://www.gnu.org/software/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.45/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['8a3eb4b10e7053312790f21ee1a38f7e2bbd6f4096abb590d3429e5119592d96']
+
+builddependencies = [
+    ('buildtools',          '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts  = 'module unload rocm xpmem ; '
+prebuildopts   = preconfigopts
+preinstallopts = preconfigopts
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    prebuildopts + 'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/l/libbfd/libbfd-2.45-cpeGNU-25.03.eb
@@ -1,0 +1,87 @@
+# Created for LUMI by Orian Louant, adapted by Jan André Reuter (JSC, FZJ)
+easyblock = 'ConfigureMake'
+
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+
+name =    'libbfd'
+version = local_libbfd_version
+
+homepage = 'https://www.gnu.org/software/binutils/'
+
+whatis = [
+    'Description: The Binary File Descriptor library (libbfd) allows the '
+    'portable manipulation of object files'
+]
+
+description = """
+ BFD is a package which allows applications to use the same routines to operate
+ on object files whatever the object file format. A new object file format can
+ be supported simply by creating a new BFD back end and adding it to the library.
+
+ BFD is split into two parts: the front end, and the back ends (one for each
+ object file format).
+
+  - The front end of BFD provides the interface to the user. It manages memory
+    and various canonical data structures. The front end also decides which back
+    end to use and when to call back end routines.
+  - The back ends provide BFD its view of the real world. Each back end provides
+    a set of calls which the BFD front end can use to maintain its canonical
+    form. The back ends also may keep around information for their own use, for
+    greater efficiency.
+
+  This package also include libiberty as most tools requiring libbfd also
+  requires it.
+"""
+
+docurls = ['https://sourceware.org/binutils/docs-2.45/bfd.html']
+software_license_urls = ['https://www.gnu.org/licenses/gpl-3.0.html']
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://ftpmirror.gnu.org/gnu/binutils']
+sources = ['binutils-%(version)s.tar.gz']
+checksums = ['8a3eb4b10e7053312790f21ee1a38f7e2bbd6f4096abb590d3429e5119592d96']
+
+builddependencies = [
+    ('buildtools',          '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('zlib', local_zlib_version),
+]
+
+preconfigopts  = 'module unload rocm xpmem ; '
+prebuildopts   = preconfigopts
+preinstallopts = preconfigopts
+
+configopts  = '--enable-shared --disable-static'
+buildopts   = 'all-bfd'
+install_cmd = 'make install-bfd'
+
+postinstallcmds = [
+    'rm -f %(installdir)s/lib/libbfd.la',
+    prebuildopts + 'cd libiberty; cc -fPIC -shared *.o -o libiberty.so',
+    'mkdir -p %(installdir)s/lib; cp libiberty/libiberty.{a,so} %(installdir)s/lib/',
+    'mkdir -p %(installdir)s/include; cp -a include/libiberty.h %(installdir)s/include/',
+    'mkdir -p %(installdir)s/include/libiberty; cp -a include/libiberty.h %(installdir)s/include/libiberty',
+]
+
+sanity_check_paths = {
+    'files': ['lib/libbfd.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modluafooter = """
+extensions( "libiberty/%(version)s")
+"""
+
+modextravars = {
+    'EBROOTLIBIBERTY': '%(installdir)s',
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeAMD-25.03.eb
@@ -1,0 +1,64 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'OPARI2'
+version = local_OPARI2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+   'Description: OPARI2 is a source-to-source instrumentation tool for OpenMP and hybrid codes.'
+]
+
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779',  # opari2-2.0.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem ; '
+prebuildopts = preconfigopts;
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeCray-25.03.eb
@@ -1,0 +1,64 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'OPARI2'
+version = local_OPARI2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+   'Description: OPARI2 is a source-to-source instrumentation tool for OpenMP and hybrid codes.'
+]
+
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779',  # opari2-2.0.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem ; '
+prebuildopts = preconfigopts;
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-2.0.9-cpeGNU-25.03.eb
@@ -1,0 +1,64 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'OPARI2'
+version = local_OPARI2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+   'Description: OPARI2 is a source-to-source instrumentation tool for OpenMP and hybrid codes.'
+]
+
+description = """
+OPARI2, the successor of Forschungszentrum Juelich's OPARI, is a
+source-to-source instrumentation tool for OpenMP and hybrid codes.
+It surrounds OpenMP directives and runtime library calls with calls
+to the POMP2 measurement interface.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/opari2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'd57139f757c5666afaaead45ed3d0954a9b98c4a6cef6b22afe672707cffd779',  # opari2-2.0.9.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem ; '
+prebuildopts = preconfigopts;
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/opari2', 'include/opari2/pomp2_lib.h'],
+    'dirs': [],
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeAMD-25.03.eb
@@ -1,0 +1,70 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeCray-25.03.eb
@@ -1,0 +1,70 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-3.1.1-cpeGNU-25.03.eb
@@ -1,0 +1,70 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+local_Python_shortversion =  '3.11'
+
+name =    'OTF2'
+version = local_OTF2_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: OTF2 or Open Trace Format 2 is a highly scalable, memory efficient event trace data format plus support library.'
+]
+
+description = """
+The Open Trace Format 2 is a highly scalable, memory efficient event trace
+data format plus support library. It is the new standard trace format for
+Scalasca, Vampir, and TAU and is open for other tools.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e',  # otf2-3.1.1.tar.gz
+]
+
+builddependencies = [
+    ('buildtools',         '%(toolchain_version)s', '', True),
+    ('craype-network-none', EXTERNAL_MODULE),
+    ('craype-accel-host',   EXTERNAL_MODULE),
+    ('cray-python',         EXTERNAL_MODULE),
+]
+
+preconfigopts = 'module unload rocm xpmem && '
+prebuildopts = preconfigopts
+
+configopts = '--enable-shared'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%s/site-packages' % local_Python_shortversion]}
+
+sanity_check_paths = {
+    'files': ['bin/otf2-config', 'include/otf2/otf2.h',
+              ('lib/libotf2.%s' % SHLIB_EXT, 'lib64/libotf2.%s' % SHLIB_EXT)],
+    'dirs': [],
+}
+sanity_check_commands = ['%(namelower)s-config --help',
+                         'python3 -s -c "import %(namelower)s"']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeAMD-25.03.eb
@@ -1,0 +1,87 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.2'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+docurls = [
+    f'PDF manual at https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-{version}/manual/html/',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-%(version)s/']
+sources =     [SOURCELOWER_TAR_GZ]
+checksums = [
+    '17e72fd908be43879955e4ed49c2732d4dbda7d295fec2d8b3af7ddafe1202a0',  # scalasca-2.6.2.tar.gz
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/libpearl.replay.a', 'lib64/libpearl.replay.a')],
+    'dirs': [],
+} 
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeCray-25.03.eb
@@ -1,0 +1,90 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.2'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+docurls = [
+    f'PDF manual at https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-{version}/manual/html/',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-%(version)s/']
+sources =     [SOURCELOWER_TAR_GZ]
+checksums = [
+    '17e72fd908be43879955e4ed49c2732d4dbda7d295fec2d8b3af7ddafe1202a0',  # scalasca-2.6.2.tar.gz
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+preconfigopts = 'module unload rocm craype-accel-amd-gfx90a && '
+preinstallopts = prebuildopts = preconfigopts
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/libpearl.replay.a', 'lib64/libpearl.replay.a')],
+    'dirs': [],
+} 
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.6.2-cpeGNU-25.03.eb
@@ -1,0 +1,87 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2023 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan André Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'ConfigureMake'
+
+local_Scalasca_version =     '2.6.2'         # https://www.scalasca.org/scalasca/software/scalasca-2.x/download.html
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =    'Scalasca'
+version = local_Scalasca_version
+
+homepage = 'https://www.scalasca.org/'
+
+whatis = [
+    'Description: Scalasca is a tool to measure and analyse program runtime behaviour'
+]
+
+description = """
+Scalasca is a software tool that supports the performance optimization of
+parallel programs by measuring and analysing their runtime behaviour. The
+analysis identifies potential performance bottlenecks -- in particular
+those concerning communication and synchronization -- and offers guidance
+in exploring their causes.
+"""
+
+docurls = [
+    f'PDF manual at https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-{version}/manual/html/',
+     'Web links to documentation of the latest version on https://scalasca.org/scalasca/front_content.php?idart=1071',
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['https://perftools.pages.jsc.fz-juelich.de/cicd/scalasca/tags/scalasca-%(version)s/']
+sources =     [SOURCELOWER_TAR_GZ]
+checksums = [
+    '17e72fd908be43879955e4ed49c2732d4dbda7d295fec2d8b3af7ddafe1202a0',  # scalasca-2.6.2.tar.gz
+]
+
+builddependencies = [
+    ('CubeWriter', local_CubeWriter_version),
+]
+
+dependencies = [
+    ('CubeLib', local_CubeLib_version),
+    ('OTF2',    local_OTF2_version),
+]
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp AUTHORS ChangeLog COPYING OPEN_ISSUES README %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scalasca', ('lib/libpearl.replay.a', 'lib64/libpearl.replay.a')],
+    'dirs': [],
+} 
+
+# note that modextrapaths can be used for relative paths only
+modextrapaths = {
+    # Ensure that local metric documentation is found by CubeGUI
+    'CUBE_DOCPATH': 'share/doc/scalasca/patterns',
+}
+
+modextravars = {
+    # Specifies an optional list of colon separated paths identifying
+    # suitable file systems for tracing. If set, the file system of
+    # trace measurements has to match at least one of the specified
+    # file systems.
+    'SCAN_TRACE_FILESYS': '/scratch:/projappl:/flash'
+}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeAMD-25.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeAMD-25.03-rocm.eb
@@ -1,0 +1,100 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.2'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.8.1'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    'be3eaee99cdd0145e518c1aa959126df45e25b61579a007d062748b2844c499c',  # scorep-9.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('cray-pmi',        EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter.
+    ('rocm',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeAMD-25.03-rocm '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+
+postinstallcmds = [
+    'make installcheck V=1 VERBOSE=1',
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README.md THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeCray-25.03-rocm.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeCray-25.03-rocm.eb
@@ -1,0 +1,108 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.2'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.8.1'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+versionsuffix = '-rocm'
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    'be3eaee99cdd0145e518c1aa959126df45e25b61579a007d062748b2844c499c',  # scorep-9.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('cray-pmi',        EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Support for HIP adapter.
+    ('rocm',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-25.03-rocm '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Add CFLAGS to prevent error of roctracer check due to path issues
+configopts += '--with-rocm=$ROCM_PATH CFLAGS="-isystem ${ROCM_PATH}/include/roctracer" '
+# Disable LLVM IR plug-in, to avoid issues because of minor version differences
+# of ROCm & Cray LLVM. LLVM IR plugin is not available for Cray compilers anyway.
+configopts += '--disable-llvm-plugin '
+# Cray CPE 25.03 doesn't correctly rpath libpgas-shmem.so, and doesn't provide the LD_LIBRARY_PATH
+# for it. Since some libraries link to it (due to libtool removing the --as-needed and --no-as-needed),
+# we need to add the rpath to avoid build checks failing as shared libraries are not self-contained anymore.
+configopts += 'LDFLAGS="-Wl,-rpath=$CRAYLIBS_X86_64" '
+configopts += 'LDFLAGS_FOR_BUILD_SCORE="-Wl,-rpath=$CRAYLIBS_X86_64" '
+
+postinstallcmds = [
+    'make installcheck V=1 VERBOSE=1',
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README.md THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeCray-25.03.eb
@@ -1,0 +1,103 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.2'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.8.1'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    'be3eaee99cdd0145e518c1aa959126df45e25b61579a007d062748b2844c499c',  # scorep-9.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM disabled for now, due to potential installcheck failure with
+    # libpgas-shmem.so.3 not being found
+    ('cray-openshmemx', EXTERNAL_MODULE),
+    ('cray-pmi',        EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeCray-25.03 '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Cray CPE 25.03 doesn't correctly rpath libpgas-shmem.so, and doesn't provide the LD_LIBRARY_PATH
+# for it. Since some libraries link to it (due to libtool removing the --as-needed and --no-as-needed),
+# we need to add the rpath to avoid build checks failing as shared libraries are not self-contained anymore.
+configopts += 'LDFLAGS="-Wl,-rpath=$CRAYLIBS_X86_64" '
+configopts += 'LDFLAGS_FOR_BUILD_SCORE="-Wl,-rpath=$CRAYLIBS_X86_64" '
+
+buildopts = " V=1 VERBOSE=1 "
+
+postinstallcmds = [
+    'make installcheck V=1 VERBOSE=1',
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README.md THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-9.2-cpeGNU-25.03.eb
@@ -1,0 +1,98 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+# Copyright:: Copyright 2013-2024 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+#             Christian Feld <c.feld@fz-juelich.de>
+#             Jan Andŕe Reuter <j.reuter@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P_minus_CPE'
+
+local_ScoreP_version =       '9.2'           # https://www.vi-hps.org/projects/score-p/
+
+local_CubeLib_version =      '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_CubeWriter_version =   '4.9'           # https://www.scalasca.org/scalasca/software/cube-4.x/download.html
+local_GOTCHA_version =       '1.0.8'         # https://gotcha.readthedocs.io/en/latest/
+local_libunwind_version  =   '1.8.1'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_libbfd_version =       '2.45'          # https://ftp.gnu.org/gnu/binutils/
+local_OPARI2_version =       '2.0.9'         # https://www.vi-hps.org/projects/score-p/
+local_OTF2_version =         '3.1.1'         # https://www.vi-hps.org/projects/score-p/
+
+name =          'Score-P'
+version =       local_ScoreP_version
+
+homepage = 'https://www.score-p.org'
+
+whatis = [
+    'Description: Score-P is a scalable performance measurement infrastructure for parallel codes',
+]
+
+description = """
+The Score-P measurement infrastructure is a highly scalable and easy-to-use
+tool suite for profiling, event tracing, and online analysis of HPC
+applications.
+"""
+
+docurls = [
+    'Web-based documentation of the latest version at https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/latest/html/',
+    'On-system documentation in $EBROOTSCOREMINP/share/doc/scorep (after loading the module)',  
+]
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+source_urls = ['http://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%(version)s']
+sources =     ['scorep-%(version)s.tar.gz']
+checksums = [
+    'be3eaee99cdd0145e518c1aa959126df45e25b61579a007d062748b2844c499c',  # scorep-9.2.tar.gz
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+]
+
+dependencies = [
+    ('CubeLib',         local_CubeLib_version),
+    ('CubeWriter',      local_CubeWriter_version),
+    # Unwinding/sampling support (optional):
+    ('libunwind',       local_libunwind_version),
+    ('OPARI2',          local_OPARI2_version),
+    ('OTF2',            local_OTF2_version),
+    # Support for SHMEM disabled for now, due to potential installcheck failure with
+    # libpgas-shmem.so.3 not being found
+    # ('cray-openshmemx', EXTERNAL_MODULE),
+    # ('cray-pmi',        EXTERNAL_MODULE),
+    ('libbfd',          local_libbfd_version),
+    # Hardware counter support (optional):
+    ('papi',            EXTERNAL_MODULE),
+    # Library wrapping
+    ('GOTCHA',          local_GOTCHA_version),
+]
+
+configopts  = '--enable-shared --disable-static --with-machine-name=LUMI-cpeGNU-25.03 '
+configopts += '--with-libpmi=/opt/cray/pe/pmi/default '
+configopts += '--with-papi-header=$CRAY_PAPI_PREFIX/include --with-papi-lib=$CRAY_PAPI_PREFIX/lib '
+# Force set correct GCC compilers, as Score-P will use /usr/bin/gcc otherwise
+configopts += 'CC=gcc-14 CXX=g++-14 F77=gfortran-14 FC=gfortran-14 '
+
+postinstallcmds = [
+    'make installcheck V=1 VERBOSE=1',
+    'mkdir -p %(installdir)s/share/licenses/%(name)s && ' +
+    'cp AUTHORS ChangeLog CITATION.cff COPYING OPEN_ISSUES README.md THANKS %(installdir)s/share/licenses/%(name)s',   
+]
+
+sanity_check_paths = {
+    'files': ['bin/scorep', 'include/scorep/SCOREP_User.h',
+              ('lib/libscorep_adapter_mpi_event.%s' % SHLIB_EXT, 'lib64/libscorep_adapter_mpi_event.%s' % SHLIB_EXT)],
+    'dirs':  [],
+}
+
+# Ensure that local metric documentation is found by CubeGUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scorep/profile'}
+
+moduleclass = 'perf'
+


### PR DESCRIPTION
More or less copy-paste of prior environments.
So far tested within the CPE 25.03 container. All installations here can install on LUMI/25.03.
cpeAOCC is missing from this PR, as it is missing from the container.

**Notable changes:**
- Score-P requires the following workaround due to issues of CPE 25.03 (see LUMI#6647):
```
configopts += 'LDFLAGS="-Wl,-rpath=$CRAYLIBS_X86_64" '
configopts += 'LDFLAGS_FOR_BUILD_SCORE="-Wl,-rpath=$CRAYLIBS_X86_64" '
```
- Updated libbfd to latest upstream version
- The OpenMP Tools Interface is now available for CCE 19.0.0 and default in Score-P. It's still not perfect (LUMI#6428), but still a notable step forward.
- Score-P now also requires `cray-pmi`, as the Cray compiler wrappers were broken otherwise.

**Things to test before moving out of draft:**
- We may be able to enable the LLVM plug-in for PrgEnv-amd now, as ROCm is newer and fixed a few known issues
- Run a few test cases to make sure the installations actually work.
- Update documentation to reflect changes by newer environment