### PR TITLE
Update SZ source repo

### DIFF
--- a/easybuild/easyconfigs/s/SZ/README.md
+++ b/easybuild/easyconfigs/s/SZ/README.md
@@ -37,3 +37,4 @@
 -   Added license information in May 2025.
 
 -   May 2025: Version added with `cray-hdf5-parallel` which was somewhat nontrivial.
+-   September 2025: `github.com/szcompressor/SZ` is now empty repo. The source is now at `github.com/szcompressor/SZ2`

--- a/easybuild/easyconfigs/s/SZ/SZ-2.1.12.5-cpeGNU-24.03-hdf5-parallel.eb
+++ b/easybuild/easyconfigs/s/SZ/SZ-2.1.12.5-cpeGNU-24.03-hdf5-parallel.eb
@@ -1,21 +1,22 @@
 # Based on a easyconfig by the Juelich Supercomputing Centre
 # Adapted for LUMI by Orian Louant
 #
-#DOC This version uses the `cray-hdf5-parallel` and `cray-netcdf-hdf5parallel` modules.
+# DOC This version uses the `cray-hdf5-parallel` and `cray-netcdf-hdf5parallel` modules.
 
-easyblock = 'CMakeMake'
+easyblock = "CMakeMake"
 
-local_zlib_version =         '1.3.1'         # https://zlib.net/
+local_zlib_version = "1.3.1"  # https://zlib.net/
+local_SZ_version = "2.1.12.5"  # https://github.com/szcompressor/SZ2/releases
 
-local_SZ_version =           '2.1.12.5'       # https://github.com/szcompressor/SZ/releases
+name = "SZ"
+version = local_SZ_version
+versionsuffix = "-hdf5-parallel"
 
-name =          'SZ'
-version =       local_SZ_version
-versionsuffix = '-hdf5-parallel'
+homepage = "https://szcompressor.org"
 
-homepage = 'https://szcompressor.org'
-
-whatis = ['SZ is a modular parametrizable lossy compressor framework for scientific data']
+whatis = [
+    "SZ is a modular parametrizable lossy compressor framework for scientific data"
+]
 
 description = """
  SZ is a modular parametrizable lossy compressor framework for scientific data
@@ -32,54 +33,65 @@ description = """
  data.
 """
 
-software_license_urls = ['https://github.com/szcompressor/SZ/blob/master/copyright-and-BSD-license.txt']
+software_license_urls = [
+    "https://github.com/szcompressor/SZ2/blob/master/copyright-and-BSD-license.txt"
+]
 
-toolchain = {'name': 'cpeGNU', 'version': '24.03'}
-toolchainopts = {'pic': True}
+toolchain = {"name": "cpeGNU", "version": "24.03"}
+toolchainopts = {"pic": True}
 
-github_account = 'szcompressor'
-source_urls = [GITHUB_SOURCE]
-sources = ['v%(version)s.tar.gz']
-checksums = ['32a820daf6019156a777300389d2392e4498a5c9daffce7be754cd0a5ba8729c']
+github_account = "szcompressor"
+source_urls = ["https://github.com/szcompressor/SZ2/releases/download/v%(version)s"]
+sources = ["SZ-%(version)s.tar.gz"]
+checksums = ["32a820daf6019156a777300389d2392e4498a5c9daffce7be754cd0a5ba8729c"]
 
 builddependencies = [
-    ('buildtools',          '%(toolchain_version)s', '', True),
-    ('craype-accel-host',   EXTERNAL_MODULE),
+    ("buildtools", "%(toolchain_version)s", "", True),
+    ("craype-accel-host", EXTERNAL_MODULE),
 ]
 
 dependencies = [
-    ('zlib',                     local_zlib_version),
-    ('cray-hdf5-parallel',       EXTERNAL_MODULE),
-    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
+    ("zlib", local_zlib_version),
+    ("cray-hdf5-parallel", EXTERNAL_MODULE),
+    ("cray-netcdf-hdf5parallel", EXTERNAL_MODULE),
 ]
 
-preconfigopts = 'module rm rocm cray-libsci && '
+preconfigopts = "module rm rocm cray-libsci && "
 prebuildopts = preconfigopts
 
-preconfigopts += ' && '.join([
-    'export PKG_CONFIG_PATH=$CRAY_MPICH_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH',
-    '; '.join([
-        'pushd %(builddir)s/SZ-%(version)s/NetCDFReader',
-        'sed -i "s/IMPORTED_TARGET netcdf/IMPORTED_TARGET netcdf_parallel/" CMakeLists.txt',
-        'popd',
-    ]),
-]) + ' && '
+preconfigopts += (
+    " && ".join(
+        [
+            "export PKG_CONFIG_PATH=$CRAY_MPICH_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH",
+            "; ".join(
+                [
+                    "pushd %(builddir)s/SZ-%(version)s/NetCDFReader",
+                    'sed -i "s/IMPORTED_TARGET netcdf/IMPORTED_TARGET netcdf_parallel/" CMakeLists.txt',
+                    "popd",
+                ]
+            ),
+        ]
+    )
+    + " && "
+)
 
-configopts = ' '.join([
-    '-DBUILD_FORTRAN=ON',
-    '-DBUILD_HDF5_FILTER=ON',
-    '-DBUILD_NETCDF_READER=ON',
-    '-DBUILD_OPENMP=ON',
-])
+configopts = " ".join(
+    [
+        "-DBUILD_FORTRAN=ON",
+        "-DBUILD_HDF5_FILTER=ON",
+        "-DBUILD_NETCDF_READER=ON",
+        "-DBUILD_OPENMP=ON",
+    ]
+)
 
 postinstallcmds = [
-    'mkdir -p %(installdir)s/share/licenses/%(name)s',
-    'cd ../%(name)s-%(version)s && cp copyright-and-BSD-license.txt %(installdir)s/share/licenses/%(name)s',   
+    "mkdir -p %(installdir)s/share/licenses/%(name)s",
+    "cd ../%(name)s-%(version)s && cp copyright-and-BSD-license.txt %(installdir)s/share/licenses/%(name)s",
 ]
 
 sanity_check_paths = {
-    'files': ['lib/libSZ.%s' % SHLIB_EXT],
-    'dirs': ['include', 'lib'],
+    "files": ["lib/libSZ.%s" % SHLIB_EXT],
+    "dirs": ["include", "lib"],
 }
 
-moduleclass = 'data'
+moduleclass = "data"

--- a/easybuild/easyconfigs/s/SZ/SZ-2.1.12.5-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/s/SZ/SZ-2.1.12.5-cpeGNU-24.03.eb
@@ -31,13 +31,15 @@ description = """
  data.
 """
 
-software_license_urls = ['https://github.com/szcompressor/SZ/blob/master/copyright-and-BSD-license.txt']
+software_license_urls = [
+    "https://github.com/szcompressor/SZ2/blob/master/copyright-and-BSD-license.txt"
+]
 
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 toolchainopts = {'pic': True}
 
 github_account = 'szcompressor'
-source_urls = [GITHUB_SOURCE]
+source_urls = ["https://github.com/szcompressor/SZ2/releases/download/v%(version)s"]
 sources = ['v%(version)s.tar.gz']
 checksums = ['32a820daf6019156a777300389d2392e4498a5c9daffce7be754cd0a5ba8729c']
 


### PR DESCRIPTION
The original [SZ](https://github.com/szcompressor/SZ) repo is now empty. The SZ2 is now available at [SZ2](https:// github.com/szcompressor/SZ2).