### PR TITLE
Cleaning-up OpenFOAM 12 and 13

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-12-cpeGNU-24.03-patch-20250206.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-12-cpeGNU-24.03-patch-20250206.eb
@@ -1,17 +1,17 @@
 # Version 10, based on instructions from Esko Järvinen, CSC
 # Updated to version 10 by Orian Louant
 # Updated to version 12 by Stanislau Stasheuski
-#DOC Deprecated EasyConfig, installing the latest from the master branch of OpenFOAM 12.
-#DOC However, it will not automatically download the latest version if this EasyConfig has
-#DOC been used before and will install whatever version was downloaded back then.
+#DOC Patch release 20250206 of OpenFOAM 12. To change to a later patch release, all that is
+#DOC needed is adapt the local_version_tag line towards the top of this file. It does not
+#DOC contain a checksum at the moment.
 
 easyblock = 'Binary'
 
-local_version_tag = 'master'
+local_version_tag = '20250206'
 
 name          = 'OpenFOAM'
 version       = '12'
-versionsuffix = f'-{local_version_tag}'
+versionsuffix = f'-patch-{local_version_tag}'
 
 homepage = 'http://www.openfoam.org/'
 
@@ -38,11 +38,12 @@ Allrun scripts require some additional tweaking.
 
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 
-source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/heads']
+# https://github.com/OpenFOAM/OpenFOAM-12/archive/refs/tags/20250206.tar.gz
+source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version)s/archive/refs/tags']
 sources     = [
     {
         'download_filename': f'{local_version_tag}.tar.gz',
-        'filename':          'OpenFOAM-%(version)s-latest.tar.gz',
+        'filename':          f'OpenFOAM-%(version)s-{local_version_tag}.tar.gz',
     }]
 patches = [
     ('wmake-rules-linux64Cray-gcc13.patch', 0),
@@ -63,7 +64,8 @@ unpack_options    = '--strip-components=1'
 extract_sources   = True
 buildininstalldir = True
 
-local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s-master'
+# This has to be the last component of %(installdir)s.
+local_project_name = f'%(version)s-%(toolchain_name)s-%(toolchain_version)s-patch-{local_version_tag}'
 
 install_cmd  = ' && '.join([
     f'./bin/tools/foamConfigurePaths --projectName {local_project_name} --dependency PARMETIS=OpenFOAM --dependency ParaView=none',

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-12-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-12-cpeGNU-24.03.eb
@@ -1,17 +1,12 @@
 # Version 10, based on instructions from Esko Järvinen, CSC
 # Updated to version 10 by Orian Louant
 # Updated to version 12 by Stanislau Stasheuski
-#DOC Deprecated EasyConfig, installing the latest from the master branch of OpenFOAM 12.
-#DOC However, it will not automatically download the latest version if this EasyConfig has
-#DOC been used before and will install whatever version was downloaded back then.
+#DOC Release version of OpenFOAM 12, without further patches.
 
-easyblock = 'Binary'
+easyblock = 'Binary' 
 
-local_version_tag = 'master'
-
-name          = 'OpenFOAM'
-version       = '12'
-versionsuffix = f'-{local_version_tag}'
+name    = 'OpenFOAM'
+version = '12'
 
 homepage = 'http://www.openfoam.org/'
 
@@ -38,11 +33,12 @@ Allrun scripts require some additional tweaking.
 
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 
-source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/heads']
+# https://github.com/OpenFOAM/OpenFOAM-12/archive/refs/tags/version-12.tar.gz
+source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/tags']
 sources     = [
     {
-        'download_filename': f'{local_version_tag}.tar.gz',
-        'filename':          'OpenFOAM-%(version)s-latest.tar.gz',
+        'download_filename': f'version-%(version)s.tar.gz',
+        'filename':          'OpenFOAM-%(version)s.tar.gz',
     }]
 patches = [
     ('wmake-rules-linux64Cray-gcc13.patch', 0),
@@ -63,7 +59,7 @@ unpack_options    = '--strip-components=1'
 extract_sources   = True
 buildininstalldir = True
 
-local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s-master'
+local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s'
 
 install_cmd  = ' && '.join([
     f'./bin/tools/foamConfigurePaths --projectName {local_project_name} --dependency PARMETIS=OpenFOAM --dependency ParaView=none',

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03-master.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03-master.eb
@@ -1,6 +1,7 @@
 # Version 10, based on instructions from Esko Järvinen, CSC
 # Updated to version 10 by Orian Louant
 # Updated to version 12 by Stanislau Stasheuski
+#DOC Deprecated naming, this EasyConfig has an identical result as OpenFOAM-13-cpeGNU-24.03.eb
 
 easyblock = 'Binary'
 
@@ -36,11 +37,12 @@ Allrun scripts require some additional tweaking.
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 
 
+# https://github.com/OpenFOAM/OpenFOAM-13/archive/refs/tags/version-13.tar.gz
 source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/tags']
 sources     = [
     {
-        'filename': f'OpenFOAM-%(version_major)s-version-%(version)s.tar.gz',
-        'download_filename': 'version-%(version)s.tar.gz',
+        'download_filename': f'version-%(version)s.tar.gz',
+        'filename':          'OpenFOAM-%(version)s.tar.gz',
     }]
 patches = [
     ('wmake-rules-linux64Cray-gcc13.patch', 0),
@@ -61,10 +63,10 @@ unpack_options    = '--strip-components=1'
 extract_sources   = True
 buildininstalldir = True
 
-local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s'
+local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s-master'
 
 install_cmd  = ' && '.join([
-    './bin/tools/foamConfigurePaths --projectName %s-%s --dependency PARMETIS=OpenFOAM --dependency ParaView=none' % (local_project_name, local_version_tag),
+    f'./bin/tools/foamConfigurePaths --projectName {local_project_name} --dependency PARMETIS=OpenFOAM --dependency ParaView=none',
     'printf "export PARMETIS_ARCH_PATH=$EBROOTPARMETIS\nexport PARMETIS_VERSION=parmetis-${EBVERSIONPARMETIS}\n" > ./etc/config.sh/parMetis',
     'sed -i \'125i    *cpeGNU*) version=%(version_major)s ;;\' ./bin/foamEtcFile',
     'source ./etc/bashrc WM_COMPILER=Cray WM_CC=cc WM_CXX=CC WM_MPLIB=CRAY-MPICH MPICH_DIR=${CRAY_MPICH_PREFIX}',

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03-patch-20250911.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03-patch-20250911.eb
@@ -1,17 +1,17 @@
 # Version 10, based on instructions from Esko Järvinen, CSC
 # Updated to version 10 by Orian Louant
 # Updated to version 12 by Stanislau Stasheuski
-#DOC Deprecated EasyConfig, installing the latest from the master branch of OpenFOAM 12.
-#DOC However, it will not automatically download the latest version if this EasyConfig has
-#DOC been used before and will install whatever version was downloaded back then.
+#DOC Patch release 20250911 of OpenFOAM 13. To change to a later patch release, all that is
+#DOC needed is adapt the local_version_tag line towards the top of this file. It does not
+#DOC contain a checksum at the moment.
 
 easyblock = 'Binary'
 
-local_version_tag = 'master'
+local_version_tag = '20250911'
 
 name          = 'OpenFOAM'
-version       = '12'
-versionsuffix = f'-{local_version_tag}'
+version       = '13'
+versionsuffix = f'-patch-{local_version_tag}'
 
 homepage = 'http://www.openfoam.org/'
 
@@ -38,11 +38,12 @@ Allrun scripts require some additional tweaking.
 
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 
-source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/heads']
+# https://github.com/OpenFOAM/OpenFOAM-13/archive/refs/tags/20250911.tar.gz
+source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version)s/archive/refs/tags']
 sources     = [
     {
         'download_filename': f'{local_version_tag}.tar.gz',
-        'filename':          'OpenFOAM-%(version)s-latest.tar.gz',
+        'filename':          f'OpenFOAM-%(version)s-{local_version_tag}.tar.gz',
     }]
 patches = [
     ('wmake-rules-linux64Cray-gcc13.patch', 0),
@@ -63,7 +64,8 @@ unpack_options    = '--strip-components=1'
 extract_sources   = True
 buildininstalldir = True
 
-local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s-master'
+# This has to be the last component of %(installdir)s.
+local_project_name = f'%(version)s-%(toolchain_name)s-%(toolchain_version)s-patch-{local_version_tag}'
 
 install_cmd  = ' && '.join([
     f'./bin/tools/foamConfigurePaths --projectName {local_project_name} --dependency PARMETIS=OpenFOAM --dependency ParaView=none',

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-13-cpeGNU-24.03.eb
@@ -1,17 +1,12 @@
 # Version 10, based on instructions from Esko Järvinen, CSC
 # Updated to version 10 by Orian Louant
 # Updated to version 12 by Stanislau Stasheuski
-#DOC Deprecated EasyConfig, installing the latest from the master branch of OpenFOAM 12.
-#DOC However, it will not automatically download the latest version if this EasyConfig has
-#DOC been used before and will install whatever version was downloaded back then.
+#DOC Release version of OpenFOAM 13, without further patches.
 
 easyblock = 'Binary'
 
-local_version_tag = 'master'
-
-name          = 'OpenFOAM'
-version       = '12'
-versionsuffix = f'-{local_version_tag}'
+name    = 'OpenFOAM'
+version = '13'
 
 homepage = 'http://www.openfoam.org/'
 
@@ -38,11 +33,12 @@ Allrun scripts require some additional tweaking.
 
 toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 
-source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/heads']
+# https://github.com/OpenFOAM/OpenFOAM-13/archive/refs/tags/version-13.tar.gz
+source_urls = ['https://github.com/OpenFOAM/OpenFOAM-%(version_major)s/archive/refs/tags']
 sources     = [
     {
-        'download_filename': f'{local_version_tag}.tar.gz',
-        'filename':          'OpenFOAM-%(version)s-latest.tar.gz',
+        'download_filename': f'version-%(version)s.tar.gz',
+        'filename':          'OpenFOAM-%(version)s.tar.gz',
     }]
 patches = [
     ('wmake-rules-linux64Cray-gcc13.patch', 0),
@@ -63,7 +59,7 @@ unpack_options    = '--strip-components=1'
 extract_sources   = True
 buildininstalldir = True
 
-local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s-master'
+local_project_name = '%(version_major)s-%(toolchain_name)s-%(toolchain_version)s'
 
 install_cmd  = ' && '.join([
     f'./bin/tools/foamConfigurePaths --projectName {local_project_name} --dependency PARMETIS=OpenFOAM --dependency ParaView=none',


### PR DESCRIPTION
Renaming old 12 and 13 EasyConfigs, deprecating the master versions and adding the last updates to version 12 and 13 in a way that users can easily do further updates.