### PR TITLE
Updated NAMD 3.0.2 checksum

### DIFF
--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-24.03-rocm-gpu-offload.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-24.03-rocm-gpu-offload.eb
@@ -90,7 +90,7 @@ toolchainopts = {'dynamic': False}
 sources = ['NAMD_%(version)s_Source.tar.gz']
 patches = ['NAMD_hip_lumi.patch']
 checksums = [
-    '4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4',
+    '0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5',
     'a932fa3b92043c571914bacd4f326cd82a232ffc8fbbea7281479f8a98f30868',
 ]
 

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-24.03-rocm-gpu-resident.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-24.03-rocm-gpu-resident.eb
@@ -85,7 +85,7 @@ toolchain = {'name': 'cpeGNU', 'version': '24.03'}
 toolchainopts = {'dynamic': False}
 
 sources = ['NAMD_%(version)s_Source.tar.gz']
-checksums = ['4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4']
+checksums = ['0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5']
 
 download_instructions = f'Manually obtain {sources[0]} at'
 download_instructions += ' https://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=NAMD'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-mpi-crayshasta.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-mpi-crayshasta.eb
@@ -79,7 +79,7 @@ toolchain = {'name': 'cpeGNU', 'version': '25.03'}
 toolchainopts = {'dynamic': False}
 
 sources = ['NAMD_%(version)s_Source.tar.gz']
-checksums = ['4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4']
+checksums = ['0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5']
 
 download_instructions  = f'Manually obtain {sources[0]} at'
 download_instructions += ' https://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=NAMD'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-ofi-crayshasta.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-ofi-crayshasta.eb
@@ -79,7 +79,7 @@ toolchain = {'name': 'cpeGNU', 'version': '25.03'}
 toolchainopts = {'dynamic': False}
 
 sources = ['NAMD_%(version)s_Source.tar.gz']
-checksums = ['4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4']
+checksums = ['0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5']
 
 download_instructions  = f'Manually obtain {sources[0]} at'
 download_instructions += ' https://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=NAMD'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-offload.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-offload.eb
@@ -83,7 +83,7 @@ toolchainopts = {'dynamic': False}
 sources = ['NAMD_%(version)s_Source.tar.gz']
 patches = ['NAMD_hip_lumi-rocm-6.3.4.patch']
 checksums = [
-    {'NAMD_3.0.2_Source.tar.gz':       '4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4'},
+    {'NAMD_3.0.2_Source.tar.gz':       '0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5'},
     {'NAMD_hip_lumi-rocm-6.3.4.patch': 'c1c6d0d04fdb60c0bcd360abaea11d15b6c6d25b928b60d29f618a1b9dc2b272'},
 ]
 

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-offload.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-offload.eb
@@ -84,7 +84,7 @@ sources = ['NAMD_%(version)s_Source.tar.gz']
 patches = ['NAMD_hip_lumi-rocm-6.3.4.patch']
 checksums = [
     {'NAMD_3.0.2_Source.tar.gz':       '0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5'},
-    {'NAMD_hip_lumi-rocm-6.3.4.patch': 'c1c6d0d04fdb60c0bcd360abaea11d15b6c6d25b928b60d29f618a1b9dc2b272'},
+    {'NAMD_hip_lumi-rocm-6.3.4.patch': 'd84a3d49234e0b8ec44a97fedd39c9085812b872a41ef645239e26522125aa6a'},
 ]
 
 download_instructions  = f'Manually obtain {sources[0]} at'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-resident.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-3.0.2-cpeGNU-25.03-rocm-gpu-resident.eb
@@ -78,7 +78,7 @@ toolchain = {'name': 'cpeGNU', 'version': '25.03'}
 toolchainopts = {'dynamic': False}
 
 sources =   ['NAMD_%(version)s_Source.tar.gz']
-checksums = ['4809360bdbe4f67aebd56847210537a24f6c785c381e501341260a7812879da4']
+checksums = ['0916700dec3342165b7ba2c3b5f99dcff767879d2a4931b5028dba47acd68bd5']
 
 download_instructions  = f'Manually obtain {sources[0]} at'
 download_instructions += ' https://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=NAMD'

--- a/easybuild/easyconfigs/n/NAMD/NAMD_hip_lumi-rocm-6.3.4.patch
+++ b/easybuild/easyconfigs/n/NAMD/NAMD_hip_lumi-rocm-6.3.4.patch
@@ -1,30 +1,25 @@
-diff --git a/NAMD_3.0_Source/arch/Linux-x86_64.hip b/NAMD_3.0_Source/arch/Linux-x86_64.hip
-index 98a2090..c177886 100644
---- a/NAMD_3.0.2_Source/arch/Linux-x86_64.hip
-+++ b/NAMD_3.0.2_Source/arch/Linux-x86_64.hip
-@@ -8,11 +8,17 @@ HIPDIR  = $(ROCMDIR)
+diff -Naur a/NAMD_3.0.2_Source/arch/Linux-x86_64.hip b/NAMD_3.0.2_Source/arch/Linux-x86_64.hip
+--- a/NAMD_3.0.2_Source/arch/Linux-x86_64.hip	2026-02-16 16:56:24.378697375 +0100
++++ b/NAMD_3.0.2_Source/arch/Linux-x86_64.hip	2026-02-16 16:57:52.758772676 +0100
+@@ -8,7 +8,7 @@
  #endif
  
  ifeq ($(PLATFORM),)
 -    PLATFORM = $(shell $(HIPDIR)/bin/hipconfig -P)
 +    PLATFORM =amd#$(shell hipconfig -P)
  endif
+ 
+ # assign ROCMV version number as "{major}.{minor}"
+@@ -26,7 +26,11 @@
+ 
  CUDADIR = $(HIPDIR)
  export HIP_PLATFORM=$(PLATFORM)
 -HIPCCOPTS = -std=c++17 -O3 -fPIE -fexpensive-optimizations -ffast-math $(shell export HIP_PLATFORM=$(PLATFORM); $(HIPDIR)/bin/hipconfig --cpp_config) 
 +HIPCCOPTS = -std=c++17 -O3 -fPIE -fexpensive-optimizations -ffast-math -D__HIP_PLATFORM_HCC__=/opt/rocm-6.3.4clang -D__HIP_PLATFORM_AMD__=amd
 +
-+#$(shell export HIP_PLATFORM=$(PLATFORM); $(HIPDIR)/bin/hipconfig --cpp_config) 
-+
-+
++#$(shell export HIP_PLATFORM=$(PLATFORM); $(HIPDIR)/bin/hipconfig --cpp_config)
 +
 +
  ifneq ($(HIPCUB_DIR),)
      HIPCCOPTS += -I$(HIPCUB_DIR)
  endif
-@@ -54,4 +60,4 @@ endif
- CUDAOBJS = $(CUDAOBJSRAW)
- CUDA = $(CUDAFLAGS) -I. $(shell export HIP_PLATFORM=$(PLATFORM); $(HIPDIR)/bin/hipconfig --cpp_config) 
- CUDACC = $(HIPCC)
--CUDACCOPTS = $(HIPCCOPTS) $(CUDAFLAGS)
-+CUDACCOPTS = $(HIPCCOPTS) $(CUDAFLAGS) 


### PR DESCRIPTION
NAMD 3.0.2  checksum appears to have changed since these configs were created.  I also checked 3.0, which appears to still be correct.

The patch for the GPU offload version also had to be altered as the file it patches appears to have been changed somewhat.