### PR TITLE
Celerity-0.7.0-cpeAMD-25.03.eb

### DIFF
--- a/easybuild/easyconfigs/c/Celerity/Celerity-0.7.0-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/c/Celerity/Celerity-0.7.0-cpeAMD-25.03.eb
@@ -36,7 +36,7 @@ sources = [{
     'git_config': {
         'url': 'https://github.com/celerity',
         'repo_name': 'celerity-runtime',
-        'commit': '8341c514069fb4e9b34eb4043851676df174a721',
+        'tag': 'v%(version)s',
         'recursive': True,
         'keep_git_dir': True,
     },


### PR DESCRIPTION
The EasyConfig had the commit of the previous version (0.6.0) hardcoded.
The proposed change in the EasyConfig uses the version tag.
Limited tests passed on LUMI-G, with version 0.7.0