### PR TITLE
fix the wps output bug

### DIFF
--- a/easybuild/easyconfigs/w/WPS/WPS-v4.4-cpeGNU-25.03-WRF-SFIRE-W4.4-S0.1.eb
+++ b/easybuild/easyconfigs/w/WPS/WPS-v4.4-cpeGNU-25.03-WRF-SFIRE-W4.4-S0.1.eb
@@ -61,6 +61,7 @@ sources = [{
 
 patches = [
     'wps.patch',
+    'patch_fixoutputgcc14.patch',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/w/WPS/patch_fixoutputgcc14.patch
+++ b/easybuild/easyconfigs/w/WPS/patch_fixoutputgcc14.patch
@@ -1,0 +1,12 @@
+diff --git a/geogrid/src/output_module.F b/geogrid/src/output_module.F
+index 072ca54..6d48ed6 100644
+--- a/geogrid/src/output_module.F
++++ b/geogrid/src/output_module.F
+@@ -469,6 +469,7 @@ module output_module
+       ifieldstatus = 0
+       nfields = 0
+       optstatus = 0
++      is_subgrid_var = .false.
+       do while (ifieldstatus == 0)
+    
+          call get_next_output_fieldname(nest_num, fieldname, ndims, &


### PR DESCRIPTION
there was a bug reported in https://rt.lumi-supercomputer.eu/Ticket/Display.html?id=8720 where a not initialized variable with gcc14 makes all the output not to be printed. solution was suggested by user in the ticket itself
